### PR TITLE
Add GitHub Action for pre-commit

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -6,7 +6,7 @@
   "runServices": ["dev"], // run "docs" here in the future
   "workspaceFolder": "/home/calitp/app",
   // "postStartCommand": ["/bin/bash", "bin/init.sh"],
-  // "postAttachCommand": ["/bin/bash", "bin/pre-commit.sh"],
+  "postAttachCommand": ["/bin/bash", "bin/pre-commit.sh"],
 
   // Set *default* container specific settings.json values on container create.
   "settings": {

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 127

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+name: Pre-commit checks
+
+on:
+  push:
+    branches: [main, test, dev]
+  pull_request:
+    branches: [main, test, dev]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,9 +2,9 @@ name: Pre-commit checks
 
 on:
   push:
-    branches: [main, test, dev]
+    branches: [main]
   pull_request:
-    branches: [main, test, dev]
+    branches: [main]
 
 jobs:
   pre-commit:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+.pytest_cache/
+.coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,5 +35,4 @@ repos:
     hooks:
       - id: bandit
         args: ["-ll"]
-        exclude: ^server/
         files: .py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v1.0.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: end-of-file-fixer
+      - id: requirements-txt-fixer
+      - id: check-yaml
+        args: ["--unsafe"]
+      - id: check-added-large-files
+
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        types:
+          - python
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        types:
+          - python
+
+  - repo: https://github.com/pycqa/bandit
+    rev: 1.7.0
+    hooks:
+      - id: bandit
+        args: ["-ll"]
+        exclude: ^server/
+        files: .py$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true,
+  "python.languageServer": "Pylance",
+}

--- a/app.py
+++ b/app.py
@@ -75,9 +75,11 @@ class Database:
 app = Flask(__name__)
 api = Api(app)
 
+
 @app.route("/healthcheck")
 def healthcheck():
     return "Healthy"
+
 
 class MerchantAuthToken(Resource):
 

--- a/bin/pre-commit.sh
+++ b/bin/pre-commit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eu
+
+# initialize hook environments
+pre-commit install --install-hooks --overwrite
+
+# manage commit-msg hooks
+pre-commit install --hook-type commit-msg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,3 @@ services:
       - 5678:5678
     volumes:
       - ./:/home/calitp/app/
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,11 @@ import pytest
 
 from app import app as server
 
+
 @pytest.fixture
 def app():
     yield server
+
 
 @pytest.fixture
 def client(app):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,4 @@
 def test_healthcheck(app, client):
-  response = client.get('/healthcheck')
-  assert response.status_code == 200
-  assert response.data == b"Healthy"
+    response = client.get("/healthcheck")
+    assert response.status_code == 200
+    assert response.data == b"Healthy"


### PR DESCRIPTION
closes #6 

- Adds GitHub Action for pre-commit
- Lints all files

## Test this PR
- Rebuild & Reopen Remote Container in VS Code. You should see these new log statements, showing that the pre-commit libraries are being downloaded:
![image](https://user-images.githubusercontent.com/3673236/135678743-9e41e46e-f39b-405e-869f-5341696005c8.png)

- Make a commit that obviously would trigger a linting error --- like remove all indents
- Make a commit
- The Precommit action should flag this commit

![image](https://user-images.githubusercontent.com/3673236/135678698-d81ed6d6-87ae-44c6-8f46-08f4dbcc0ad8.png)
