### PR TITLE
Upgrade jwcrypto and cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==3.4.7
+cryptography==35.0.0
 Flask==2.0.2
 Flask-RESTful==0.3.9
 jwcrypto==1.0


### PR DESCRIPTION
- chore: upgrade jwcrypto to 1.0
- chore: upgrade cryptography to 35.0.0

closes #26 

## how to test
1. In server, checkout the branch with the dependency updates, and `docker compose build server`
1. In benefits, checkout the branch with the dependency updates, and `docker compose build client`
1. In benefits, update the server.image in docker compose file to point to the local `eligibility_server:latest`
1. Rebuild and Reopen devcontainer. Run app in Debugger mode.
1. Open benefits app client to admin and ensure this is correct

![image](https://user-images.githubusercontent.com/3673236/139158041-37016d16-6cb2-4e25-8daa-4e63831da4aa.png)

1. Test flow for an eligible user and an ineligible user

** May have to reset the database: **
```
rm django.db
bin/init.sh
```

** Remember to use http://localhost:xxxx, not 0.0.0.0:xxxx

** Note: Reaching this error is expected

![image](https://user-images.githubusercontent.com/3673236/139160707-0903bfcb-ab20-4b3f-8171-26b631cec480.png)

## resources

- Changelog for jwcrypto: https://github.com/latchset/jwcrypto/releases/tag/v1.0.0
- See all the commits between 0.9.1 to 1.0 https://github.com/latchset/jwcrypto/compare/v0.9.1...v1.0.0
- Changelog for crytography: https://cryptography.io/en/latest/changelog/