### PR TITLE
Docs deploy GitHub Action *paths* filter

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    filter:
+    paths:
       - 'docs/**'
       - '.github/workflows/mkdocs.yml'
       - 'mkdocs.yml'


### PR DESCRIPTION
closes #42 

---

The Docs Deploy action has been running on _every_ merge to `main`. This action was intended to only be run if files related to docs are updated. The reason the `filter` wasn't working was because it should be called `paths:`, not `filter:`