### PR TITLE
Set up Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,15 +14,6 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-  - package-ecosystem: "pip"
-    directory: "/tests" # tests/requirements.txt
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore(deps): "
-      include: "scope"
-    labels:
-      - "dependencies"
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`


### PR DESCRIPTION
closes #28 

## What this PR does
- Enable and configure Dependabot to scan the app for dependency updates
- Which dependencies? `requirements.txt`, `tests/requirements.txt` and GitHub Actions
- Frequency: Daily
- With a pull request with a `dependencies` label and commit message with `chore(deps):` prefix

## Docs
- Dependency updates: https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
- Security updates: https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/configuring-dependabot-security-updates