### PR TITLE
Pin conventional-precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v1.0.0
+    rev: v1
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]


### PR DESCRIPTION
closes #46 


FYI - This warning will come up:

`
[WARNING] The 'rev' field of repo 'https://github.com/compilerla/conventional-pre-commit' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
`

But we decided it's okay, because the Dev Container always will install only once.