### PR TITLE
chore: configure vscode test debugging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,4 +2,10 @@
   "python.linting.flake8Enabled": true,
   "python.linting.enabled": true,
   "python.languageServer": "Pylance",
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "python.pythonPath": "/usr/local/bin/python3",
 }


### PR DESCRIPTION
Enabling these settings allows the developer to use VS Code's native testing tools to run the test suite in this application.

![image](https://user-images.githubusercontent.com/3673236/149241705-fbe0097e-0df8-45c0-bcb2-120119ab80a2.png)


More on VSCode Python testing configuration: https://code.visualstudio.com/docs/python/testing#_test-configuration-settings