### PR TITLE
Add settings test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,6 @@ jobs:
           source tests/.env.settingstest
           coverage run -m pytest -m settingstest
           coverage report -m
-          set +a
           set -a
           source tests/.env.tests
           coverage run -m pytest -m "not settingstest"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Test with pytest
         run: |
           set -a
-          source tests/.env.tests
-          coverage run -m pytest -m "not settingstest"
-          set +a
-          set -a
           source tests/.env.settingstest
           coverage run -m pytest -m settingstest
           coverage report -m
+          set +a
+          set -a
+          source tests/.env.tests
+          coverage run -m pytest -m "not settingstest"
           set +a

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,12 +3,6 @@ name: Run pytests
 on:
   pull_request:
     branches: [ "*" ]
-    paths:
-      - 'data/**'
-      - 'eligibility_server/**'
-      - 'keys/**'
-      - 'tests/**'
-      - 'requirements.txt'
 
 jobs:
   tests:
@@ -27,7 +21,6 @@ jobs:
           source tests/.env.settingstest
           coverage run -m pytest -m settingstest
           coverage report -m
-          set -a
           source tests/.env.tests
           coverage run -m pytest -m "not settingstest"
           set +a

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,5 +26,9 @@ jobs:
           set -a
           source tests/.env.tests
           coverage run -m pytest -m "not settingstest"
+          set +a
+          set -a
+          source tests/.env.settingstests
+          coverage run -m pytest -m settingstest
           coverage report -m
           set +a

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
           coverage run -m pytest -m "not settingstest"
           set +a
           set -a
-          source tests/.env.settingstests
+          source tests/.env.settingstest
           coverage run -m pytest -m settingstest
           coverage report -m
           set +a

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,6 +25,6 @@ jobs:
         run: |
           set -a
           source tests/.env.tests
-          coverage run -m pytest
+          coverage run -m pytest -m "not settingstest"
           coverage report -m
           set +a

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    settingstest: mark a test to be run with .env.settingstest

--- a/tests/.env.settingstest
+++ b/tests/.env.settingstest
@@ -1,0 +1,1 @@
+INPUT_HASH_ALGO=sha512

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -3,14 +3,24 @@ Test hash class method
 """
 import pytest
 
-
 from eligibility_server.hash import Hash
 
 
-def test_hash_init():
-    hash = Hash("whirlpool")
+test_data = [
+    (Hash("sha256").hash_input("Test"), "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25"),
+    (
+        Hash("sha512").hash_input("Test"),
+        "c6ee9e33cf5c6715a1d148fd73f7318884b41adcb916021e2bc0e800a5c5dd97f5142178f6ae88c8fdd98e1afb0ce4c8d2c54b5f37b30b7da1997bb33b0b8a31",  # noqa: E501
+    ),
+    (
+        Hash("whirlpool").hash_input("Test"),
+        "ac1c196e84b05d59faea639d0cccb6c16f7568e0943f4c94c648bd8eefe5cf3978f8d4f99b1426e4ce3c6fa40e17cf68d6b86d42246333569b963ff4579c6355",  # noqa: E501
+    ),
+]
 
-    assert hash._input_hash_algo == "whirlpool"
+
+def test_hash_init():
+    assert Hash("whirlpool")._input_hash_algo == "whirlpool"
 
 
 def test_hash_init_invalid_type():
@@ -23,28 +33,6 @@ def test_hash_init_invalid_blank():
         Hash()
 
 
-def test_hash_input_default():
-    hash = Hash("sha256")
-    hashed_string = hash.hash_input("Test")
-
-    assert hashed_string == "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25"  # noqa: E501
-
-
-def test_hash_input_sha512():
-    hash = Hash("sha512")
-    hashed_string = hash.hash_input("Test")
-
-    assert (
-        hashed_string
-        == "c6ee9e33cf5c6715a1d148fd73f7318884b41adcb916021e2bc0e800a5c5dd97f5142178f6ae88c8fdd98e1afb0ce4c8d2c54b5f37b30b7da1997bb33b0b8a31"  # noqa: E501
-    )
-
-
-def test_hash_input_whirlpool():
-    hash = Hash("whirlpool")
-    hashed_string = hash.hash_input("Test")
-
-    assert (
-        hashed_string
-        == "ac1c196e84b05d59faea639d0cccb6c16f7568e0943f4c94c648bd8eefe5cf3978f8d4f99b1426e4ce3c6fa40e17cf68d6b86d42246333569b963ff4579c6355"  # noqa: E501
-    )
+@pytest.mark.parametrize("input, expected", test_data)
+def test_hash_input(input, expected):
+    assert input == expected

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -7,13 +7,13 @@ from eligibility_server.hash import Hash
 
 
 test_data = [
-    (Hash("sha256").hash_input("Test"), "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25"),
+    ("sha256", "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25"),
     (
-        Hash("sha512").hash_input("Test"),
+        "sha512",
         "c6ee9e33cf5c6715a1d148fd73f7318884b41adcb916021e2bc0e800a5c5dd97f5142178f6ae88c8fdd98e1afb0ce4c8d2c54b5f37b30b7da1997bb33b0b8a31",  # noqa: E501
     ),
     (
-        Hash("whirlpool").hash_input("Test"),
+        "whirlpool",
         "ac1c196e84b05d59faea639d0cccb6c16f7568e0943f4c94c648bd8eefe5cf3978f8d4f99b1426e4ce3c6fa40e17cf68d6b86d42246333569b963ff4579c6355",  # noqa: E501
     ),
 ]
@@ -33,6 +33,6 @@ def test_hash_init_invalid_blank():
         Hash()
 
 
-@pytest.mark.parametrize("input, expected", test_data)
-def test_hash_input(input, expected):
-    assert input == expected
+@pytest.mark.parametrize("hash_input_algo, expected", test_data)
+def test_hash_input(hash_input_algo, expected):
+    assert Hash(hash_input_algo).hash_input("Test") == expected

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 """
 Test config settings
 """
+import pytest
 
 from eligibility_server import settings
 
@@ -18,6 +19,11 @@ def test_settings():
 
 def test_hash_settings():
     assert settings.INPUT_HASH_ALGO == "sha256"
+
+
+@pytest.mark.settingstest
+def test_hash_settings_env():
+    assert settings.INPUT_HASH_ALGO == "sha512"
 
 
 def test_debug():


### PR DESCRIPTION
closes #54 

## What this PR does:
- Adds 1 test to the `test_settings` file - this test should test that a new `.env` file with a different `INPUT_HASH_ALGO` variable will appropriately set that new value to `settings.INPUT_HASH_ALGO`.
- Adds 1 new `.env.settingstest` file to be used on the new test, with the custom marker, `@pytest.mark.settingstest`
- Adds 1 new `pytest.ini` file to register the new custom marker
- Changes the `run_test` GitHub Action to run the test suite twice: on the first run, test all but the `@pytest.mark.settingstest` spec, and on the second run, run only that spec. In between the two runs, run `source tests/.env.settingstest` so that the test environment can read from the 2nd .env file
- Refactors `test_database` and `test_hash` with parameterization


## How I'm using the custom `@pytest.mark`
1. Register the mark in `pytest.ini` - to document the mark and what it means. This isn't required for implementation, but is highly recommended:

```ini
[pytest]
markers =
    settingstest: mark a test to be run with .env.settingstest
```

2. Use the custom mark in a method: `@pytest.mark.settingstest`:

```python
@pytest.mark.settingstest
def test_hash_settings_env():
    assert settings.INPUT_HASH_ALGO == "sha512"
```

3. Call `pytest` using the mark:

```bash
## Run all test with the mark
coverage run -m pytest -m settingstest
```

```bash
## Run all tests without the mark
coverage run -m pytest -m "not settingstest"
```

This is what the output looks like:

```bash
## Run all test with the mark
======================= 1 passed, 23 deselected in 0.10s =======================
```

```bash
## Run all tests without the mark
======================= 23 passed, 1 deselected in 2.09s =======================
```