### PR TITLE
fix(Dockerfile): add build-essential, so that pre-commit can be installed

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,7 @@ USER root
 # install tooling: curl, git, jq, ssh
 # install python tooling: pip, flake8, pre-commit
 RUN apt-get update \
-    && apt-get install -qq --no-install-recommends curl git jq ssh \
+    && apt-get install -qq --no-install-recommends curl git jq ssh build-essential \
     && python -m pip install --upgrade pip
 
 RUN pip install --no-cache-dir flake8 pre-commit coverage pytest


### PR DESCRIPTION
fix #83 