### PR TITLE
Feat: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default to benefits-admin team
+* @cal-itp/benefits-admin


### PR DESCRIPTION
Adds a `CODEOWNERS` file, which defaults all reviews to the @cal-itp/benefits-admin team.

Read more about this file: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners