### PR TITLE
Feat: production container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,15 @@
-FROM python:3.10
+FROM ghcr.io/cal-itp/docker-python-web:main
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    USER=calitp \
-    FLASK_APP=eligibility_server/app.py
-
-# create $USER and home directory
-RUN useradd --create-home --shell /bin/bash $USER && \
-    chown -R $USER /home/$USER
-
-RUN apt-get update \
-    && apt-get install -qq --no-install-recommends build-essential \
-    && python -m pip install --upgrade pip
-
-# enter app directory
-WORKDIR /home/$USER/app
-
-# switch to non-root $USER
-USER $USER
-
-# update PATH for local pip installs
-ENV PATH "$PATH:/home/$USER/.local/bin"
+ENV FLASK_APP=eligibility_server/app.py
 
 # install python app dependencies
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # copy source files
-COPY . /home/$USER/app/
+COPY bin/ .
+COPY eligibility_server/ .
+COPY *.py .
 
 # start app
 ENTRYPOINT ["/bin/bash"]

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,4 +1,4 @@
-#! usr/bin/env bash
+#!/usr/bin/env bash
 set -eux
 
 # run database migrations

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,4 +1,4 @@
-#! usr/bin/env bash
+#!/usr/bin/env bash
 set -eux
 
 # initialize Flask

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -7,4 +7,6 @@ bin/init.sh
 
 # start the web server
 
-flask run -h 0.0.0.0
+nginx
+
+python -m gunicorn -c $GUNICORN_CONF eligibility_server.app:app

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
     env_file: .env
     image: eligibility_server:latest
     ports:
-      - "5000"
+      - "8000"
     volumes:
       - .:/home/calitp/app/
 
@@ -19,15 +19,15 @@ services:
     env_file: .env
     image: eligibility_server:dev
     ports:
-      - "5000"
+      - "8000"
     volumes:
       - .:/home/calitp/app/
 
   docs:
     image: eligibility_server:dev
     entrypoint: mkdocs
-    command: serve --dev-addr "0.0.0.0:8000"
+    command: serve --dev-addr "0.0.0.0:8001"
     ports:
-      - "8000"
+      - "8001"
     volumes:
       - .:/home/calitp/app

--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -57,4 +57,4 @@ class User(db.Model):
 
 
 if __name__ == "__main__":
-    app.run(host=app.config["HOST"], debug=app.config["DEBUG_MODE"])  # nosec
+    app.run(host=app.config["HOST"], debug=app.config["DEBUG_MODE"], port="8000")  # nosec


### PR DESCRIPTION
Closes #111 

This PR changes the base image to use our new [`cal-itp/docker-python-web`](https://github.com/cal-itp/docker-python-web) image hosted on [GitHub Container Registry](https://github.com/cal-itp/docker-python-web/pkgs/container/docker-python-web).

This base image bakes in `nginx` and `gunicorn` - and `bin/start.sh` runs the app through those services.

Developers shouldn't notice a difference running the app locally - either inside the devcontainer in debug mode, or by running the container with `docker compose`.