### PR TITLE
Refactor: Database class - remove in memory data

### DIFF
--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -48,12 +48,12 @@ db = SQLAlchemy(app)
 
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.String, unique=True, nullable=False)
-    key = db.Column(db.String, unique=True, nullable=False)
+    sub = db.Column(db.String, unique=True, nullable=False)
+    name = db.Column(db.String, unique=True, nullable=False)
     types = db.Column(db.String, unique=False, nullable=False)
 
     def __repr__(self):
-        return "<User %r>" % self.user_id
+        return "<User %r>" % self.sub
 
 
 if __name__ == "__main__":

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -5,6 +5,9 @@ Simple hard-coded server database.
 import ast
 
 from . import app
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Database:
@@ -17,9 +20,9 @@ class Database:
 
         self._hash = hash
         if hash:
-            app.app.logger.debug(f"Database initialized with hash: {hash}")
+            logger.debug(f"Database initialized with hash: {hash}")
         else:
-            app.app.logger.debug("Database initialized without hashing")
+            logger.debug("Database initialized without hashing")
 
     def check_user(self, key: str, user: str, types: str) -> list:
         """
@@ -44,15 +47,13 @@ class Database:
             existing_user_types = None
 
         if len(types) < 1:
-            app.app.logger.debug("List of types to check was empty.")
+            logger.debug("List of types to check was empty.")
             return []
         elif existing_user is None:
-            app.app.logger.debug(f"Database does not contain requested user with sub, name: {key, user}")
+            logger.debug(f"Database does not contain requested user with sub, name: {key, user}")
             return []
         elif len(set(existing_user_types) & set(types)) < 1:
-            app.app.logger.debug(
-                f"Database contains user with matching sub and name, but user's types do not contain: {types}"
-            )
+            logger.debug(f"Database contains user with matching sub and name, but user's types do not contain: {types}")
             return []
         else:
             return list(set(existing_user_types) & set(types))

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -24,23 +24,23 @@ class Database:
         else:
             logger.debug("Database initialized without hashing")
 
-    def check_user(self, key: str, user: str, types: str) -> list:
+    def check_user(self, sub: str, name: str, types: str) -> list:
         """
         Check if the data matches a record in the database
 
         @param self: self
-        @param key: key to check for
-        @param user: name of user to check for
+        @param sub: sub to check for
+        @param name: name of user to check for
         @param types: type of eligibility
 
         @return list of strings of types user is eligible for, or empty list
         """
 
         if self._hash:
-            key = self._hash.hash_input(key)
-            user = self._hash.hash_input(user)
+            sub = self._hash.hash_input(sub)
+            name = self._hash.hash_input(name)
 
-        existing_user = app.User.query.filter_by(sub=key, name=user).first()
+        existing_user = app.User.query.filter_by(sub=sub, name=name).first()
         if existing_user:
             existing_user_types = ast.literal_eval(existing_user.types)
         else:
@@ -50,7 +50,7 @@ class Database:
             logger.debug("List of types to check was empty.")
             return []
         elif existing_user is None:
-            logger.debug(f"Database does not contain requested user with sub, name: {key, user}")
+            logger.debug(f"Database does not contain requested user with sub, name: {sub, name}")
             return []
         elif len(set(existing_user_types) & set(types)) < 1:
             logger.debug(f"Database contains user with matching sub and name, but user's types do not contain: {types}")

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -44,7 +44,9 @@ class Database:
         if existing_user:
             existing_user_types = ast.literal_eval(existing_user.types)
         else:
-            existing_user_types = None
+            existing_user_types = []
+
+        matching_types = set(existing_user_types) & set(types)
 
         if len(types) < 1:
             logger.debug("List of types to check was empty.")
@@ -52,9 +54,8 @@ class Database:
         elif existing_user is None:
             logger.debug("Database does not contain requested user.")
             return []
-        elif len(set(existing_user_types) & set(types)) < 1:
-            logger.debug(f"Database contains user with matching sub and name, but user's types do not contain: {types}")
+        elif len(matching_types) < 1:
+            logger.debug(f"User's types do not contain any of the requested types: {types}")
             return []
         else:
-            matching_types = set(existing_user_types) & set(types)
             return list(matching_types)

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -56,4 +56,5 @@ class Database:
             logger.debug(f"Database contains user with matching sub and name, but user's types do not contain: {types}")
             return []
         else:
-            return list(set(existing_user_types) & set(types))
+            matching_types = set(existing_user_types) & set(types)
+            return list(matching_types)

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -44,12 +44,19 @@ class Database:
             key = self._hash.hash_input(key)
             user = self._hash.hash_input(user)
 
-        if (
-            len(types) < 1
-            or key not in self._users
-            or self._users[key][0] != user
-            or len(set(self._users[key][1]) & set(types)) < 1
-        ):
+        if len(types) < 1:
+            app.app.logger.debug("List of types to check was empty.")
+            return []
+        elif key not in self._users:
+            app.app.logger.debug(f"Database does not contain requested sub: {key}")
+            return []
+        elif self._users[key][0] != user:
+            app.app.logger.debug(f"Database contains user with matching sub, but does not match name: {user}")
+            return []
+        elif len(set(self._users[key][1]) & set(types)) < 1:
+            app.app.logger.debug(
+                f"Database contains user with matching sub and name, but user's types do not contain: {types}"
+            )
             return []
 
         return list(set(self._users[key][1]) & set(types))

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -44,14 +44,13 @@ class Database:
             key = self._hash.hash_input(key)
             user = self._hash.hash_input(user)
 
+        existing_user = app.User.query.filter_by(user_id=key, key=user).first()
+
         if len(types) < 1:
             app.app.logger.debug("List of types to check was empty.")
             return []
-        elif key not in self._users:
-            app.app.logger.debug(f"Database does not contain requested sub: {key}")
-            return []
-        elif self._users[key][0] != user:
-            app.app.logger.debug(f"Database contains user with matching sub, but does not match name: {user}")
+        elif existing_user is None:
+            app.app.logger.debug(f"Database does not contain requested user with sub, name: {key, user}")
             return []
         elif len(set(self._users[key][1]) & set(types)) < 1:
             app.app.logger.debug(

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -36,6 +36,10 @@ class Database:
         @return list of strings of types user is eligible for, or empty list
         """
 
+        if len(types) < 1:
+            logger.debug("List of types to check was empty.")
+            return []
+
         if self._hash:
             sub = self._hash.hash_input(sub)
             name = self._hash.hash_input(name)
@@ -48,10 +52,7 @@ class Database:
 
         matching_types = set(existing_user_types) & set(types)
 
-        if len(types) < 1:
-            logger.debug("List of types to check was empty.")
-            return []
-        elif existing_user is None:
+        if existing_user is None:
             logger.debug("Database does not contain requested user.")
             return []
         elif len(matching_types) < 1:

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -50,7 +50,7 @@ class Database:
             logger.debug("List of types to check was empty.")
             return []
         elif existing_user is None:
-            logger.debug(f"Database does not contain requested user with sub, name: {sub, name}")
+            logger.debug("Database does not contain requested user.")
             return []
         elif len(set(existing_user_types) & set(types)) < 1:
             logger.debug(f"Database contains user with matching sub and name, but user's types do not contain: {types}")

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -40,7 +40,7 @@ class Database:
             key = self._hash.hash_input(key)
             user = self._hash.hash_input(user)
 
-        existing_user = app.User.query.filter_by(user_id=key, key=user).first()
+        existing_user = app.User.query.filter_by(sub=key, name=user).first()
         if existing_user:
             existing_user_types = ast.literal_eval(existing_user.types)
         else:

--- a/eligibility_server/database.py
+++ b/eligibility_server/database.py
@@ -16,6 +16,10 @@ class Database:
         """
 
         self._hash = hash
+        if hash:
+            app.app.logger.debug(f"Database initialized with hash: {hash}")
+        else:
+            app.app.logger.debug("Database initialized without hashing")
 
         users = app.User.query.all()
         all_users = {}

--- a/setup.py
+++ b/setup.py
@@ -44,16 +44,16 @@ def import_users():
     logger.info(f"Users added: {app.User.query.count()}")
 
 
-def save_users(user_id: str, key: str, types: str):
+def save_users(sub: str, name: str, types: str):
     """
     Add users to the database User table
 
-    @param user_id - User's ID, not to be confused with Database row ID
-    @param key - User's key
+    @param sub - User's ID, not to be confused with Database row ID
+    @param name - User's name
     @param types - Types of eligibilities, in a stringified list
     """
 
-    item = app.User(user_id=user_id, key=key, types=types)
+    item = app.User(sub=sub, name=name, types=types)
     app.db.session.add(item)
     app.db.session.commit()
 

--- a/teardown.py
+++ b/teardown.py
@@ -9,9 +9,13 @@ if __name__ == "__main__":
     inspector = inspect(app.db.engine)
 
     if inspector.get_table_names():
-        logger.info(f"Users to be deleted: {app.User.query.count()}")
-        app.User.query.delete()
-        app.db.session.commit()
+        try:
+            logger.info(f"Users to be deleted: {app.User.query.count()}")
+            app.User.query.delete()
+            app.db.session.commit()
+        except Exception as e:
+            logger.warning("Failed to query for Users", e)
+
         app.db.drop_all()
         logger.info("Database dropped.")
     else:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -25,7 +25,6 @@ test_data = [
 def test_database_init_default():
     database = Database()
 
-    assert database._users
     assert database._hash is False
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,14 +9,14 @@ from eligibility_server.hash import Hash
 
 
 test_data = [
-    (Database(), "A1234567", "Garcia", ["type1"], ["type1"]),  # This key/user pair is in the database
-    (Database(), "A1234567", "Garcia", ["type2"], []),  # This key/user pair does not have "type2" in its associated array
-    (Database(), "A1234567", "Aaron", ["type1"], []),  # This key/user pair does not exist
+    (Database(), "A1234567", "Garcia", ["type1"], ["type1"]),  # This sub/name pair is in the database
+    (Database(), "A1234567", "Garcia", ["type2"], []),  # This sub/name pair does not have "type2" in its associated array
+    (Database(), "A1234567", "Aaron", ["type1"], []),  # This sub/name pair does not exist
     (Database(), "G7778889", "Thomas", ["type1"], []),  # User not in database
-    (Database(Hash("sha256")), "A1234568", "Garcia", ["type1"], ["type1"]),  # Correct key/user pair and correct hash algo type
-    (Database(Hash("sha256")), "A1234568", "Garcia", ["type2"], []),  # This key/user pair does not have "type2" in its array
-    (Database(Hash("sha256")), "A1234568", "Aaron", ["type1"], []),  # This key/user pair does not exist
-    (Database(Hash("sha256")), "G7778889", "Thomas", ["type1"], []),  # User does not exist
+    (Database(Hash("sha256")), "A1234568", "Garcia", ["type1"], ["type1"]),  # Correct sub/name pair and correct hash algo type
+    (Database(Hash("sha256")), "A1234568", "Garcia", ["type2"], []),  # This sub/name pair does not have "type2" in its array
+    (Database(Hash("sha256")), "A1234568", "Aaron", ["type1"], []),  # This sub/name pair does not exist
+    (Database(Hash("sha256")), "G7778889", "Thomas", ["type1"], []),  # name does not exist
     (Database(Hash("sha512")), "D4567891", "James", ["type1"], ["type1"]),  # Specific hash algo type
     (Database(Hash("sha256")), "D4567891", "James", ["type1"], []),  # Wrong hash algo type
 ]
@@ -28,6 +28,6 @@ def test_database_init_default():
     assert database._hash is False
 
 
-@pytest.mark.parametrize("db, key, user, types, expected", test_data)
-def test_database_check_user(db, key, user, types, expected):
-    assert db.check_user(key, user, types) == expected
+@pytest.mark.parametrize("db, sub, name, types, expected", test_data)
+def test_database_check_user(db, sub, name, types, expected):
+    assert db.check_user(sub, name, types) == expected


### PR DESCRIPTION
This PR covers the feedback items in the description of #122:

- Query for user in `check_user` which allows us to remove the `_user` variable that was holding all users in-memory
- Log the `hash` being used, and split out conditions in `check_user` to add logging for each
- Separate out calculation of matching types from return statement