### PR TITLE
Chore: specify 8000 as port in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,7 @@
             ],
             "env": {
                 "FLASK_DEBUG": "1",
+                "FLASK_RUN_PORT": "8000",
                 "ELIGIBILITY_SERVER_SETTINGS": "../config/sample.py"
             },
         },


### PR DESCRIPTION
@machikoyasuda and I noticed that when launching `eligibility-server` from the VS Code debugger, it was being served at 5000 instead of a dynamic port like it used to.

![image](https://user-images.githubusercontent.com/25497886/187786171-80c78f5d-3664-454e-9137-c81958e7d96e.png)

Looks like this started happening when the devcontainer's port was changed from [5000 to 8000](https://github.com/cal-itp/eligibility-server/pull/123/files#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588).

This PR restores the old behavior by specifying in `launch.json` that 8000 should be the port for Flask to serve the app at (instead of the default 5000).