### PR TITLE
Feat: settings/configuration helper

### DIFF
--- a/config/sample.py
+++ b/config/sample.py
@@ -1,6 +1,6 @@
-IMPORT_FILE_PATH = "data/server.csv"
-INPUT_HASH_ALGO = "sha256"
-CSV_DELIMITER = ";"
-CSV_NEWLINE = ""
-CSV_QUOTING = 3
-CSV_QUOTECHAR = ""
+# Override default settings by re-declaring the variables with new values
+# e.g. (uncomment)
+#
+# IMPORT_FILE_PATH = "another/source.csv"
+# INPUT_HASH_ALGO = ""
+# CSV_DELIMITER = ","

--- a/eligibility_server/db/setup.py
+++ b/eligibility_server/db/setup.py
@@ -5,7 +5,12 @@ import click
 from flask import current_app
 from flask_sqlalchemy import inspect
 
-from eligibility_server.db.models import db, User
+from eligibility_server.db import db
+from eligibility_server.db.models import User
+from eligibility_server.settings import Configuration
+
+
+config = Configuration()
 
 
 @click.command("init-db")
@@ -36,7 +41,7 @@ def import_users():
     CSV_DELIMITER, CSV_NEWLINE, CSV_QUOTING, CSV_QUOTECHAR
     """
 
-    file_path = current_app.config["IMPORT_FILE_PATH"]
+    file_path = config.import_file_path
     click.echo(f"Importing users from {file_path}")
 
     file_format = file_path.split(".")[-1]
@@ -47,12 +52,12 @@ def import_users():
             for user in data:
                 save_users(user, data[user][0], str(data[user][1]))
     elif file_format == "csv":
-        with open(file_path, newline=current_app.config["CSV_NEWLINE"], encoding="utf-8") as file:
+        with open(file_path, newline=config.csv_newline, encoding="utf-8") as file:
             data = csv.reader(
                 file,
-                delimiter=current_app.config["CSV_DELIMITER"],
-                quoting=int(current_app.config["CSV_QUOTING"]),
-                quotechar=current_app.config["CSV_QUOTECHAR"],
+                delimiter=config.csv_delimiter,
+                quoting=config.csv_quoting,
+                quotechar=config.csv_quotechar,
             )
             for user in data:
                 save_users(user[0], user[1], user[2])

--- a/eligibility_server/keypair.py
+++ b/eligibility_server/keypair.py
@@ -3,9 +3,10 @@ import logging
 from jwcrypto import jwk
 import requests
 
-from eligibility_server import app
+from eligibility_server.settings import Configuration
 
 
+config = Configuration()
 logger = logging.getLogger(__name__)
 
 
@@ -29,18 +30,18 @@ def _read_key_file(key_path):
 
 
 def get_client_public_key():
-    key_path = app.app.config["CLIENT_KEY_PATH"]
+    key_path = config.client_key_path
     logger.info(f"Reading client key file: {key_path}")
     return _read_key_file(key_path)
 
 
 def get_server_private_key():
-    key_path = app.app.config["SERVER_PRIVATE_KEY_PATH"]
+    key_path = config.server_private_key_path
     logger.info(f"Reading server private key file: {key_path}")
     return _read_key_file(key_path)
 
 
 def get_server_public_key():
-    key_path = app.app.config["SERVER_PUBLIC_KEY_PATH"]
+    key_path = config.server_public_key_path
     logger.info(f"Reading server public key file: {key_path}")
     return _read_key_file(key_path)

--- a/eligibility_server/settings.py
+++ b/eligibility_server/settings.py
@@ -32,12 +32,12 @@ SUB_FORMAT_REGEX = ".*"
 
 # Data settings
 
-IMPORT_FILE_PATH = ""
-INPUT_HASH_ALGO = ""
+IMPORT_FILE_PATH = "data/server.csv"
+INPUT_HASH_ALGO = "sha256"
 
 # CSV-specific settings
 
-CSV_DELIMITER = ","
+CSV_DELIMITER = ";"
 CSV_NEWLINE = ""
 CSV_QUOTING = 3
 CSV_QUOTECHAR = ""

--- a/eligibility_server/settings.py
+++ b/eligibility_server/settings.py
@@ -1,6 +1,7 @@
 """
 Default settings for server.
 """
+from flask import current_app
 
 # App settings
 
@@ -41,3 +42,95 @@ CSV_DELIMITER = ";"
 CSV_NEWLINE = ""
 CSV_QUOTING = 3
 CSV_QUOTECHAR = ""
+
+
+class Configuration:
+    # App settings
+
+    @property
+    def app_name(self):
+        return str(current_app.config["APP_NAME"])
+
+    @property
+    def debug_mode(self):
+        return bool(current_app.config["DEBUG_MODE"])
+
+    @property
+    def host(self):
+        return str(current_app.config["HOST"])
+
+    @property
+    def log_level(self):
+        return str(current_app.config["LOG_LEVEL"])
+
+    # API settings
+
+    @property
+    def auth_header(self):
+        return str(current_app.config["AUTH_HEADER"])
+
+    @property
+    def auth_token(self):
+        return str(current_app.config["AUTH_TOKEN"])
+
+    @property
+    def token_header(self):
+        return str(current_app.config["TOKEN_HEADER"])
+
+    # Eligibility Verification settings
+
+    @property
+    def client_key_path(self):
+        return str(current_app.config["CLIENT_KEY_PATH"])
+
+    @property
+    def jwe_cek_enc(self):
+        return str(current_app.config["JWE_CEK_ENC"])
+
+    @property
+    def jwe_encryption_alg(self):
+        return str(current_app.config["JWE_ENCRYPTION_ALG"])
+
+    @property
+    def jws_signing_alg(self):
+        return str(current_app.config["JWS_SIGNING_ALG"])
+
+    @property
+    def server_private_key_path(self):
+        return str(current_app.config["SERVER_PRIVATE_KEY_PATH"])
+
+    @property
+    def server_public_key_path(self):
+        return str(current_app.config["SERVER_PUBLIC_KEY_PATH"])
+
+    @property
+    def sub_format_regex(self):
+        return str(current_app.config["SUB_FORMAT_REGEX"])
+
+    # Data settings
+
+    @property
+    def import_file_path(self):
+        return str(current_app.config["IMPORT_FILE_PATH"])
+
+    @property
+    def input_hash_algo(self):
+        return str(current_app.config["INPUT_HASH_ALGO"])
+
+    # CSV-specific settings
+
+    @property
+    def csv_delimiter(self):
+        return str(current_app.config["CSV_DELIMITER"])
+
+    @property
+    def csv_newline(self):
+        return str(current_app.config["CSV_NEWLINE"])
+
+    @property
+    def csv_quoting(self):
+        return int(current_app.config["CSV_QUOTING"])
+
+    @property
+    def csv_quotechar(self):
+        return str(current_app.config["CSV_QUOTECHAR"])

--- a/eligibility_server/verify.py
+++ b/eligibility_server/verify.py
@@ -9,15 +9,17 @@ import logging
 import re
 import time
 
-from flask import abort, current_app
+from flask import abort
 from flask_restful import Resource, reqparse
 from jwcrypto import jwe, jws, jwt
 
 from eligibility_server import keypair
 from eligibility_server.db.models import User
 from eligibility_server.hash import Hash
+from eligibility_server.settings import Configuration
 
 
+config = Configuration()
 logger = logging.getLogger(__name__)
 
 
@@ -27,8 +29,8 @@ class Verify(Resource):
         self.client_public_key = keypair.get_client_public_key()
         self.server_private_key = keypair.get_server_private_key()
 
-        if current_app.config["INPUT_HASH_ALGO"] != "":
-            hash = Hash(current_app.config["INPUT_HASH_ALGO"])
+        if config.input_hash_algo != "":
+            hash = Hash(config.input_hash_algo)
             logger.debug(f"Verify initialized with hash: {hash}")
         else:
             hash = None
@@ -39,19 +41,19 @@ class Verify(Resource):
     def _check_headers(self):
         """Ensure correct request headers."""
         req_parser = reqparse.RequestParser()
-        req_parser.add_argument(current_app.config["TOKEN_HEADER"], location="headers", required=True)
-        req_parser.add_argument(current_app.config["AUTH_HEADER"], location="headers", required=True)
+        req_parser.add_argument(config.token_header, location="headers", required=True)
+        req_parser.add_argument(config.auth_header, location="headers", required=True)
         headers = req_parser.parse_args()
 
         # verify auth_header's value
-        if headers.get(current_app.config["AUTH_HEADER"]) == current_app.config["AUTH_TOKEN"]:
+        if headers.get(config.auth_header) == config.auth_token:
             return headers
         else:
             return False
 
     def _get_token(self, headers):
         """Get the token from request headers"""
-        token = headers.get(current_app.config["TOKEN_HEADER"], "").split(" ")
+        token = headers.get(config.token_header, "").split(" ")
         if len(token) == 2:
             return token[1]
         elif len(token) == 1:
@@ -64,12 +66,12 @@ class Verify(Resource):
         """Decode a token (JWE(JWS))."""
         try:
             # decrypt
-            decrypted_token = jwe.JWE(algs=[current_app.config["JWE_ENCRYPTION_ALG"], current_app.config["JWE_CEK_ENC"]])
+            decrypted_token = jwe.JWE(algs=[config.jwe_encryption_alg, config.jwe_cek_enc])
             decrypted_token.deserialize(token, key=self.server_private_key)
             decrypted_payload = str(decrypted_token.payload, "utf-8")
             # verify signature
             signed_token = jws.JWS()
-            signed_token.deserialize(decrypted_payload, key=self.client_public_key, alg=current_app.config["JWS_SIGNING_ALG"])
+            signed_token.deserialize(decrypted_payload, key=self.client_public_key, alg=config.jws_signing_alg)
             # return final payload
             payload = str(signed_token.payload, "utf-8")
             return json.loads(payload)
@@ -80,12 +82,12 @@ class Verify(Resource):
     def _make_token(self, payload):
         """Wrap payload in a signed and encrypted JWT for response."""
         # sign the payload with server's private key
-        header = {"typ": "JWS", "alg": current_app.config["JWS_SIGNING_ALG"]}
+        header = {"typ": "JWS", "alg": config.jws_signing_alg}
         signed_token = jwt.JWT(header=header, claims=payload)
         signed_token.make_signed_token(self.server_private_key)
         signed_payload = signed_token.serialize()
         # encrypt the signed payload with client's public key
-        header = {"typ": "JWE", "alg": current_app.config["JWE_ENCRYPTION_ALG"], "enc": current_app.config["JWE_CEK_ENC"]}
+        header = {"typ": "JWE", "alg": config.jwe_encryption_alg, "enc": config.jwe_cek_enc}
         encrypted_token = jwt.JWT(header=header, claims=signed_payload)
         encrypted_token.make_encrypted_token(self.client_public_key)
         return encrypted_token.serialize()
@@ -96,11 +98,11 @@ class Verify(Resource):
             sub, name, eligibility = token_payload["sub"], token_payload["name"], list(token_payload["eligibility"])
             resp_payload = dict(
                 jti=token_payload["jti"],
-                iss=current_app.config["APP_NAME"],
+                iss=config.app_name,
                 iat=int(datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).timestamp()),
             )
             # sub format check
-            if re.match(current_app.config["SUB_FORMAT_REGEX"], sub):
+            if re.match(config.sub_format_regex, sub):
                 # eligibility check against db
                 resp_payload["eligibility"] = self._check_user(sub, name, eligibility)
                 code = 200

--- a/tests/test_keypair.py
+++ b/tests/test_keypair.py
@@ -1,17 +1,20 @@
 import builtins
-from os.path import exists
-from tempfile import NamedTemporaryFile
 
 import pytest
 import requests
 
 from eligibility_server import keypair
-from eligibility_server.keypair import get_client_public_key, get_server_private_key, get_server_public_key
+from eligibility_server.keypair import _read_key_file
 
 
 @pytest.fixture
-def open_spy(mocker):
-    return mocker.spy(builtins, "open")
+def sample_key_path_local():
+    return "./keys/server.pub"
+
+
+@pytest.fixture
+def sample_key_path_remote():
+    return "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub"
 
 
 @pytest.fixture
@@ -19,106 +22,50 @@ def reset_cache():
     keypair._CACHE = {}
 
 
-KEY_PATH_SETTINGS = ["CLIENT_KEY_PATH", "SERVER_PRIVATE_KEY_PATH", "SERVER_PUBLIC_KEY_PATH"]
-
-REMOTE_KEYS = list(
-    zip(
-        (
-            "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/client.pub",
-            "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.key",
-            # TODO: omitted until file exists in main branch
-            # "https://raw.githubusercontent.com/cal-itp/eligibility-server/main/keys/server.pub",
-        ),
-        KEY_PATH_SETTINGS,
-    )
-)
+@pytest.fixture
+def spy_open(mocker):
+    return mocker.spy(builtins, "open")
 
 
-@pytest.mark.parametrize("key_path_setting", KEY_PATH_SETTINGS)
+@pytest.fixture
+def spy_requests_get(mocker):
+    return mocker.spy(requests, "get")
+
+
 @pytest.mark.usefixtures("reset_cache")
-def test_get_keypair_default(flask, mocker, open_spy, key_path_setting):
-    assert key_path_setting in flask.config
-    default_path = flask.config[key_path_setting]
-    assert exists(default_path)
-
-    if "CLIENT" in key_path_setting:
-        key = get_client_public_key()
-    elif "PRIVATE" in key_path_setting:
-        key = get_server_private_key()
-    elif "PUBLIC" in key_path_setting:
-        key = get_server_public_key()
+def test_read_key_file_local(mocker, sample_key_path_local, spy_open):
+    key = _read_key_file(sample_key_path_local)
 
     # check that there was a call to open the default path
-    assert mocker.call(default_path, "rb") in open_spy.call_args_list
+    assert mocker.call(sample_key_path_local, "rb") in spy_open.call_args_list
     assert key
     assert key.key_id
     assert key.key_type == "RSA"
 
 
 @pytest.mark.usefixtures("reset_cache")
-@pytest.mark.parametrize("key_path_setting", KEY_PATH_SETTINGS)
-def test_get_keypair_custom(flask, mocker, open_spy, key_path_setting):
-    default_path = flask.config[key_path_setting]
-
-    # copy the sample key into tempfile
-    with NamedTemporaryFile("wb") as tf:
-        assert tf.name != default_path
-        assert tf.name not in flask.config
-
-        with open(default_path, "rb") as df:
-            tf.write(df.read())
-            tf.seek(0)
-
-        mocked_config = {key_path_setting: tf.name}
-        mocker.patch.dict("eligibility_server.keypair.app.app.config", mocked_config)
-
-        if "CLIENT" in key_path_setting:
-            key = get_client_public_key()
-        elif "PRIVATE" in key_path_setting:
-            key = get_server_private_key()
-        elif "PUBLIC" in key_path_setting:
-            key = get_server_public_key()
-
-        # check that there was a call to open the tempfile path
-        assert mocker.call(tf.name, "rb") in open_spy.call_args_list
-        assert key
-        assert key.key_id
-        assert key.key_type == "RSA"
-
-
-@pytest.mark.usefixtures("reset_cache")
-@pytest.mark.parametrize("key_path,key_path_setting", REMOTE_KEYS)
-def test_get_keypair_remote(mocker, open_spy, key_path_setting, key_path):
-    mocked_config = {key_path_setting: key_path}
-    mocker.patch.dict("eligibility_server.keypair.app.app.config", mocked_config)
-    requests_spy = mocker.spy(requests, "get")
-
-    if "CLIENT" in key_path_setting:
-        key = get_client_public_key()
-    elif "PRIVATE" in key_path_setting:
-        key = get_server_private_key()
-    elif "PUBLIC" in key_path_setting:
-        key = get_server_public_key()
+def test_read_key_file_remote(sample_key_path_remote, spy_open, spy_requests_get):
+    key = _read_key_file(sample_key_path_remote)
 
     # check that there was no call to open
-    assert open_spy.call_count == 0
+    assert spy_open.call_count == 0
     # check that we made a get request
-    requests_spy.assert_called_with(key_path)
+    spy_requests_get.assert_called_with(sample_key_path_remote)
     assert key
     assert key.key_id
     assert key.key_type == "RSA"
 
 
 @pytest.mark.usefixtures("reset_cache")
-@pytest.mark.parametrize("key_path_setting", KEY_PATH_SETTINGS)
-def test_keypair_cache(key_path_setting):
+def test_keypair_cache(sample_key_path_local, sample_key_path_remote):
     assert keypair._CACHE == {}
 
-    if "CLIENT" in key_path_setting:
-        key = get_client_public_key()
-    elif "PRIVATE" in key_path_setting:
-        key = get_server_private_key()
-    elif "PUBLIC" in key_path_setting:
-        key = get_server_public_key()
-
+    key = _read_key_file(sample_key_path_local)
+    assert sample_key_path_local in keypair._CACHE
     assert key in keypair._CACHE.values()
+    assert sample_key_path_remote not in keypair._CACHE
+
+    key = _read_key_file(sample_key_path_remote)
+    assert sample_key_path_remote in keypair._CACHE
+    assert key in keypair._CACHE.values()
+    assert sample_key_path_local in keypair._CACHE

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,227 @@
+import pytest
+
+from eligibility_server import settings
+from eligibility_server.settings import Configuration
+
+
+@pytest.fixture
+def configuration():
+    return Configuration()
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_app_name(mocker, configuration: Configuration):
+    assert configuration.app_name == settings.APP_NAME
+
+    mocked_config = {"APP_NAME": "new name!"}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.app_name == "new name!"
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_debug_mode(mocker, configuration: Configuration):
+    assert configuration.debug_mode == settings.DEBUG_MODE
+
+    mocked_config = {"DEBUG_MODE": False}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert not configuration.debug_mode
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_host(mocker, configuration: Configuration):
+    assert configuration.host == settings.HOST
+
+    new_value = "http://example.com"
+    mocked_config = {"HOST": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.host == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_log_level(mocker, configuration: Configuration):
+    assert configuration.log_level == settings.LOG_LEVEL
+
+    new_value = "ERROR"
+    mocked_config = {"LOG_LEVEL": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.log_level == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_auth_header(mocker, configuration: Configuration):
+    assert configuration.auth_header == settings.AUTH_HEADER
+
+    new_value = "Some-New-Header"
+    mocked_config = {"AUTH_HEADER": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.auth_header == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_auth_token(mocker, configuration: Configuration):
+    assert configuration.auth_token == settings.AUTH_TOKEN
+
+    new_value = "some-new-token"
+    mocked_config = {"AUTH_TOKEN": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.auth_token == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_token_header(mocker, configuration: Configuration):
+    assert configuration.token_header == settings.TOKEN_HEADER
+
+    new_value = "Token"
+    mocked_config = {"TOKEN_HEADER": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.token_header == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_client_key_path(mocker, configuration: Configuration):
+    assert configuration.client_key_path == settings.CLIENT_KEY_PATH
+
+    new_value = "./new/path"
+    mocked_config = {"CLIENT_KEY_PATH": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.client_key_path == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_jwe_cek_enc(mocker, configuration: Configuration):
+    assert configuration.jwe_cek_enc == settings.JWE_CEK_ENC
+
+    new_value = "encoding"
+    mocked_config = {"JWE_CEK_ENC": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.jwe_cek_enc == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_jwe_encryption_alg(mocker, configuration: Configuration):
+    assert configuration.jwe_encryption_alg == settings.JWE_ENCRYPTION_ALG
+
+    new_value = "alg"
+    mocked_config = {"JWE_ENCRYPTION_ALG": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.jwe_encryption_alg == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_jws_signing_alg(mocker, configuration: Configuration):
+    assert configuration.jws_signing_alg == settings.JWS_SIGNING_ALG
+
+    new_value = "alg"
+    mocked_config = {"JWS_SIGNING_ALG": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.jws_signing_alg == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_server_private_key_path(mocker, configuration: Configuration):
+    assert configuration.server_private_key_path == settings.SERVER_PRIVATE_KEY_PATH
+
+    new_path = "./new/path"
+    mocked_config = {"SERVER_PRIVATE_KEY_PATH": new_path}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.server_private_key_path == new_path
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_server_public_key_path(mocker, configuration: Configuration):
+    assert configuration.server_public_key_path == settings.SERVER_PUBLIC_KEY_PATH
+
+    new_path = "./new/path"
+    mocked_config = {"SERVER_PUBLIC_KEY_PATH": new_path}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.server_public_key_path == new_path
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_sub_format_regex(mocker, configuration: Configuration):
+    assert configuration.sub_format_regex == settings.SUB_FORMAT_REGEX
+
+    new_value = r"[a-z]\d{6}"
+    mocked_config = {"SUB_FORMAT_REGEX": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.sub_format_regex == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_import_file_path(mocker, configuration: Configuration):
+    assert configuration.import_file_path == settings.IMPORT_FILE_PATH
+
+    new_value = "./new/path.csv"
+    mocked_config = {"IMPORT_FILE_PATH": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.import_file_path == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_input_hash_algo(mocker, configuration: Configuration):
+    assert configuration.input_hash_algo == settings.INPUT_HASH_ALGO
+
+    new_value = "hash"
+    mocked_config = {"INPUT_HASH_ALGO": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.input_hash_algo == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_csv_delimiter(mocker, configuration: Configuration):
+    assert configuration.csv_delimiter == settings.CSV_DELIMITER
+
+    new_value = "-"
+    mocked_config = {"CSV_DELIMITER": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.csv_delimiter == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_csv_newline(mocker, configuration: Configuration):
+    assert configuration.csv_newline == settings.CSV_NEWLINE
+
+    new_value = "-"
+    mocked_config = {"CSV_NEWLINE": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.csv_newline == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_csv_quoting(mocker, configuration: Configuration):
+    assert configuration.csv_quoting == settings.CSV_QUOTING
+
+    new_value = 0
+    mocked_config = {"CSV_QUOTING": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.csv_quoting == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_csv_quotechar(mocker, configuration: Configuration):
+    assert configuration.csv_quotechar == settings.CSV_QUOTECHAR
+
+    new_value = "$"
+    mocked_config = {"CSV_QUOTECHAR": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.csv_quotechar == new_value

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -29,7 +29,7 @@ def test_Verify_client_get_bad_request(mocker, client):
 @pytest.mark.usefixtures("flask")
 def test_Verify_get_response_sub_format_match(mocker):
     mocked_config = {"SUB_FORMAT_REGEX": r"^[A-Z]\d{7}$", "INPUT_HASH_ALGO": ""}
-    mocker.patch.dict("eligibility_server.verify.current_app.config", mocked_config)
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
 
     token_payload = json.loads(json.dumps(dict(sub="A1234567", name="Garcia", eligibility=["type1"], jti=str(uuid.uuid4()))))
 
@@ -38,9 +38,10 @@ def test_Verify_get_response_sub_format_match(mocker):
     assert response_code == 200
 
 
+@pytest.mark.usefixtures("flask")
 def test_Verify_get_response_sub_format_no_match(mocker):
     mocked_config = {"SUB_FORMAT_REGEX": r"^[A-Z]\d{7}$", "INPUT_HASH_ALGO": ""}
-    mocker.patch.dict("eligibility_server.verify.current_app.config", mocked_config)
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
 
     # "sub" value does not match the format regex
     token_payload = json.loads(json.dumps(dict(sub="nomatch", name="Garcia", eligibility=["type1"], jti=str(uuid.uuid4()))))
@@ -76,7 +77,7 @@ test_data = [
 @pytest.mark.parametrize("hash, sub, name, types, expected", test_data)
 def test_check_user(mocker, hash, sub, name, types, expected):
     mocked_config = {"INPUT_HASH_ALGO": hash}
-    mocker.patch.dict("eligibility_server.verify.current_app.config", mocked_config)
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
 
     verify = Verify()
     assert verify._check_user(sub, name, types) == expected


### PR DESCRIPTION
Closes #142 

~Based on #140, will keep up to date with that branch and wait for it to be merged to `main`.~

Introduces a new `Configuration` class in the `settings.py` module, with `@property` attributes for each of the settings `VARIABLES`. Property names are the `lower_case` version of their setting.

Use it like:

```python
from eligibility_server.settings import Configuration

config = Configuration()

print(config.input_hash_algo)
```

_Note: omitted the `SQLALCHEMY` settings as these are not used directly in the app code._