### PR TITLE
Fix: configure root logger

### DIFF
--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -15,8 +15,15 @@ app = Flask(__name__)
 app.config.from_object("eligibility_server.settings")
 app.config.from_envvar("ELIGIBILITY_SERVER_SETTINGS", silent=True)
 
-app.logger.setLevel(app.config["LOG_LEVEL"])
-default_handler.formatter = logging.Formatter("[%(asctime)s] %(levelname)s %(name)s:%(lineno)s %(message)s")
+log_level = app.config["LOG_LEVEL"]
+format_string = "[%(asctime)s] %(levelname)s %(name)s:%(lineno)s %(message)s"
+
+# configure Flask's logger
+app.logger.setLevel(log_level)
+default_handler.formatter = logging.Formatter(format_string)
+
+# configure root logger
+logging.basicConfig(level=log_level, format=format_string)
 
 
 def TextResponse(content):


### PR DESCRIPTION
Related to #139 

This PR makes sure that in addition to configuring Flask's logger (which Flask uses internally), we also configure the root logger. This is so that loggers we create from the standard logging module are configured correctly.

Our code doesn't need to use `app.logger` because I believe there is nothing to be gained from using it over just a normal `logger`, and I think we'd rather use not have to import `current_app` everywhere that needs logging.

## Steps to Reproduce
 - Launch the server with default settings
 - Go to the `/verify` endpoint, e.g. in a browser
 - Look at the logs

## Expected behavior
Since the log level in default settings is `INFO`, you should see at least that level.
Something like:
```
* Tip: There are .env or .flaskenv files present. Do "pip install python-dotenv" to use them.
[2022-09-07 15:27:33,742] WARNING werkzeug:224  * Debugger is active!
[2022-09-07 15:27:33,742] INFO werkzeug:224  * Debugger PIN: 575-180-751
[2022-09-07 15:28:02,697] INFO eligibility_server.keypair:33 Reading client key file: ./keys/client.pub
[2022-09-07 15:28:02,715] INFO eligibility_server.keypair:39 Reading server private key file: ./keys/server.key
[2022-09-07 15:28:02,759] INFO eligibility_server.hash:22 Input hash algorithm set to: sha256
[2022-09-07 15:28:04,762] ERROR eligibility_server.verify:125 Forbidden
[2022-09-07 15:28:04,765] INFO werkzeug:224 172.24.0.1 - - [07/Sep/2022 15:28:04] "GET /verify HTTP/1.1" 403 -
```

## Actual behavior
Not seeing any `INFO` logs, and also not seeing formatted log messages. It is as if the `logger` is not configured.
```
* Tip: There are .env or .flaskenv files present. Do "pip install python-dotenv" to use them.
* Debugger is active!
* Debugger PIN: 575-180-751
Forbidden
172.24.0.1 - - [07/Sep/2022 15:29:46] "GET /verify HTTP/1.1" 403 -
```