### PR TITLE
Chore: build script for docker images

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eux
+
+docker compose build server
+
+docker compose build dev


### PR DESCRIPTION
Just a simple helper script to reduce typing when trying to rebuild the `server` and `dev` images from scratch.