### PR TITLE
Feat: load remote data

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,24 +1,39 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Flask: Eligibility Verification Server",
-            "type": "python",
-            "request": "launch",
-            "module": "flask",
-            "args": [
-                "run",
-                "--host",
-                "0.0.0.0"
-            ],
-            "env": {
-                "FLASK_DEBUG": "1",
-                "FLASK_RUN_PORT": "8000",
-                "ELIGIBILITY_SERVER_SETTINGS": "../config/sample.py"
-            },
-        },
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Flask: Eligibility Verification Server",
+      "type": "python",
+      "request": "launch",
+      "module": "flask",
+      "args": ["run", "--host", "0.0.0.0"],
+      "env": {
+        "FLASK_DEBUG": "1",
+        "FLASK_RUN_PORT": "8000"
+      }
+    },
+    {
+      "name": "Flask: Eligibility Verification Setup",
+      "type": "python",
+      "request": "launch",
+      "module": "flask",
+      "args": ["init-db"],
+      "env": {
+        "FLASK_DEBUG": "1"
+      }
+    },
+    {
+      "name": "Flask: Eligibility Verification Teardown",
+      "type": "python",
+      "request": "launch",
+      "module": "flask",
+      "args": ["drop-db"],
+      "env": {
+        "FLASK_DEBUG": "1"
+      }
+    }
+  ]
 }

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eux
 
-docker compose build server
+docker compose build --pull server
 
 docker compose build dev

--- a/eligibility_server/db/setup.py
+++ b/eligibility_server/db/setup.py
@@ -83,6 +83,7 @@ def import_csv_users(csv_path, remote):
     if remote:
         # download the content as text and write to a temp file
         content = requests.get(csv_path).text
+        # note we leave the temp file open so it exists later for reading
         temp_csv = NamedTemporaryFile(mode="w", encoding="utf-8")
         temp_csv.write(content)
         # reset the file pointer to the beginning for reading, and reset path
@@ -90,6 +91,8 @@ def import_csv_users(csv_path, remote):
         csv_path = temp_csv.name
 
     # open the file and read it with a csv.reader
+    # open in read mode explicitly since the file may still be open if we downloaded from remote
+    # newline="" is important here, see https://docs.python.org/3/library/csv.html#id3
     with open(csv_path, mode="r", encoding="utf-8", newline="") as file:
         data = csv.reader(
             file,

--- a/eligibility_server/db/setup.py
+++ b/eligibility_server/db/setup.py
@@ -4,6 +4,7 @@ import json
 import click
 from flask import current_app
 from flask_sqlalchemy import inspect
+import requests
 
 from eligibility_server.db import db
 from eligibility_server.db.models import User, Eligibility
@@ -34,45 +35,71 @@ def init_db_command():
 
 def import_users():
     """
-    Imports user data to be added to database and saves user to database
-
-    Users can be imported from either a JSON file or CSV file, as configured
-    with settings. CSV files take extra setting configurations:
-    CSV_DELIMITER, CSV_NEWLINE, CSV_QUOTING, CSV_QUOTECHAR
+    Imports user data to database, from either a local or remote JSON or CSV file,
+    given the `IMPORT_FILE_PATH` setting.
+    CSV files take extra settings: `CSV_DELIMITER`, `CSV_NEWLINE`, `CSV_QUOTING`, `CSV_QUOTECHAR`
     """
 
-    file_path = config.import_file_path
-    click.echo(f"Importing users from {file_path}")
+    path = config.import_file_path
+    click.echo(f"Importing users from: {path}")
 
-    file_format = file_path.split(".")[-1]
+    format = path.split(".")[-1].lower()
+    remote = path.lower().startswith("http")
 
-    if file_format == "json":
-        with open(file_path) as file:
-            data = json.load(file)["users"]
-            for user in data:
-                save_users(user, data[user][0], data[user][1])
-    elif file_format == "csv":
-        with open(file_path, newline=config.csv_newline, encoding="utf-8") as file:
-            data = csv.reader(
-                file,
-                delimiter=config.csv_delimiter,
-                quoting=config.csv_quoting,
-                quotechar=config.csv_quotechar,
-            )
-            for user in data:
-                # lists are expected to be a comma-separated value and quoted if the CSV delimiter is a comma
-                types = [type.replace(config.csv_quotechar, "") for type in user[2].split(",") if type]
-                save_users(user[0], user[1], types)
-    else:
-        click.echo(f"Warning: File format is not supported: {file_format}")
+    if format not in ["json", "csv"]:
+        click.warning(f"File format is not supported: {format}")
+        return
+
+    if format == "json":
+        import_json_users(path, remote)
+    elif format == "csv":
+        import_csv_users(path, remote)
 
     click.echo(f"Users added: {User.query.count()}")
     click.echo(f"Eligibility types added: {Eligibility.query.count()}")
 
 
-def save_users(sub: str, name: str, types):
+def import_json_users(json_path, remote):
+    data = {}
+    if remote:
+        # download the file to a dict
+        data = requests.get(json_path).json()
+    else:
+        # open the file and load to a dict
+        with open(json_path) as file:
+            data = json.load(file)
+    if "users" in data:
+        data = data["users"]
+    # unpack from the key/value pairs in data
+    # sub = [name, types]
+    for sub, (name, types) in data.items():
+        save_user(sub, name, types)
+
+
+def import_csv_users(csv_path, remote):
+    if remote:
+        # download the entire content as text, split on the lineterminator to a list of rows
+        content = requests.get(csv_path).text.strip().split(config.csv_newline)
+    else:
+        # open the file and read its lines into a list of rows
+        with open(csv_path, newline=config.csv_newline, encoding="utf-8") as file:
+            content = file.readlines()
+    # read rows with reader, saving each user
+    data = csv.reader(
+        content,
+        delimiter=config.csv_delimiter,
+        quoting=config.csv_quoting,
+        quotechar=config.csv_quotechar,
+    )
+    for user in data:
+        # lists are expected to be a comma-separated value and quoted if the CSV delimiter is a comma
+        types = [type.replace(config.csv_quotechar, "") for type in user[2].split(",") if type]
+        save_user(user[0], user[1], types)
+
+
+def save_user(sub: str, name: str, types: str):
     """
-    Add users to the database User table
+    Add a user to the database User table
 
     @param sub - User's sub
     @param name - User's name

--- a/eligibility_server/db/setup.py
+++ b/eligibility_server/db/setup.py
@@ -1,5 +1,6 @@
 import csv
 import json
+from tempfile import NamedTemporaryFile
 
 import click
 from flask import current_app
@@ -37,7 +38,7 @@ def import_users():
     """
     Imports user data to database, from either a local or remote JSON or CSV file,
     given the `IMPORT_FILE_PATH` setting.
-    CSV files take extra settings: `CSV_DELIMITER`, `CSV_NEWLINE`, `CSV_QUOTING`, `CSV_QUOTECHAR`
+    CSV files take extra settings: `CSV_DELIMITER`, `CSV_QUOTING`, `CSV_QUOTECHAR`
     """
 
     path = config.import_file_path
@@ -78,23 +79,31 @@ def import_json_users(json_path, remote):
 
 def import_csv_users(csv_path, remote):
     if remote:
-        # download the entire content as text, split on the lineterminator to a list of rows
-        content = requests.get(csv_path).text.strip().split(config.csv_newline)
-    else:
-        # open the file and read its lines into a list of rows
-        with open(csv_path, newline=config.csv_newline, encoding="utf-8") as file:
-            content = file.readlines()
-    # read rows with reader, saving each user
-    data = csv.reader(
-        content,
-        delimiter=config.csv_delimiter,
-        quoting=config.csv_quoting,
-        quotechar=config.csv_quotechar,
-    )
-    for user in data:
-        # lists are expected to be a comma-separated value and quoted if the CSV delimiter is a comma
-        types = [type.replace(config.csv_quotechar, "") for type in user[2].split(",") if type]
-        save_user(user[0], user[1], types)
+        # download the content as text and write to a temp file
+        content = requests.get(csv_path).text
+        temp_csv = NamedTemporaryFile(mode="w", encoding="utf-8")
+        temp_csv.write(content)
+        # reset the file pointer to the beginning for reading, and reset path
+        temp_csv.seek(0)
+        csv_path = temp_csv.name
+
+    # open the file and read it with a csv.reader
+    with open(csv_path, mode="r", encoding="utf-8") as file:
+        data = csv.reader(
+            file,
+            delimiter=config.csv_delimiter,
+            quoting=config.csv_quoting,
+            quotechar=config.csv_quotechar,
+        )
+        # unpack each record in data to the 3 columns
+        for (sub, name, types) in data:
+            # type lists are expected to be a comma-separated value and quoted if the CSV delimiter is a comma
+            types = [type.replace(config.csv_quotechar, "") for type in types.split(",") if type]
+            save_user(sub, name, types)
+
+    # close and remove the temp file if needed
+    if temp_csv:
+        temp_csv.close()
 
 
 def save_user(sub: str, name: str, types: str):

--- a/eligibility_server/db/setup.py
+++ b/eligibility_server/db/setup.py
@@ -78,6 +78,8 @@ def import_json_users(json_path, remote):
 
 
 def import_csv_users(csv_path, remote):
+    # placeholder for a temp file that remote is downloaded to
+    temp_csv = None
     if remote:
         # download the content as text and write to a temp file
         content = requests.get(csv_path).text

--- a/eligibility_server/db/setup.py
+++ b/eligibility_server/db/setup.py
@@ -88,7 +88,7 @@ def import_csv_users(csv_path, remote):
         csv_path = temp_csv.name
 
     # open the file and read it with a csv.reader
-    with open(csv_path, mode="r", encoding="utf-8") as file:
+    with open(csv_path, mode="r", encoding="utf-8", newline="") as file:
         data = csv.reader(
             file,
             delimiter=config.csv_delimiter,

--- a/eligibility_server/settings.py
+++ b/eligibility_server/settings.py
@@ -39,7 +39,6 @@ INPUT_HASH_ALGO = "sha256"
 # CSV-specific settings
 
 CSV_DELIMITER = ";"
-CSV_NEWLINE = "\n"
 CSV_QUOTING = 3
 CSV_QUOTECHAR = '"'
 
@@ -122,10 +121,6 @@ class Configuration:
     @property
     def csv_delimiter(self):
         return str(current_app.config["CSV_DELIMITER"])
-
-    @property
-    def csv_newline(self):
-        return str(current_app.config["CSV_NEWLINE"])
 
     @property
     def csv_quoting(self):

--- a/eligibility_server/settings.py
+++ b/eligibility_server/settings.py
@@ -39,7 +39,7 @@ INPUT_HASH_ALGO = "sha256"
 # CSV-specific settings
 
 CSV_DELIMITER = ";"
-CSV_NEWLINE = ""
+CSV_NEWLINE = "\n"
 CSV_QUOTING = 3
 CSV_QUOTECHAR = '"'
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -195,17 +195,6 @@ def test_configuration_csv_delimiter(mocker, configuration: Configuration):
 
 
 @pytest.mark.usefixtures("flask")
-def test_configuration_csv_newline(mocker, configuration: Configuration):
-    assert configuration.csv_newline == settings.CSV_NEWLINE
-
-    new_value = "-"
-    mocked_config = {"CSV_NEWLINE": new_value}
-    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
-
-    assert configuration.csv_newline == new_value
-
-
-@pytest.mark.usefixtures("flask")
 def test_configuration_csv_quoting(mocker, configuration: Configuration):
     assert configuration.csv_quoting == settings.CSV_QUOTING
 


### PR DESCRIPTION
Closes #143.

Simple check if `IMPORT_FILE_PATH` starts with `http`, using `requests.get(path)` to download the file.

* For `json`, file content is loaded to a Python dict
* For `csv`, text content is downloaded to a temp file and read as normal

Also adds debug settings (via `launch.json`) for the database setup/teardown process.

## Testing

1. Update your `IMPORT_FILE_PATH` to point to the raw URL of one of the sample data files, e.g. https://raw.githubusercontent.com/cal-itp/eligibility-server/main/data/server.csv
2. Run `flask drop-db` to drop the existing database, if any
3. In the VS Code _Run and Debug_ tab, select the `Flask: Eligibility Verification Setup` launch item
4. Place breakpoints in the `eligibility_server/db/setup.py` module as appropriate, and hit `F5` to run the `init-db` command

~Sitting on top of #149 for now.~