### PR TITLE
Fix: use runtime expression syntax for variables

### DIFF
--- a/terraform/pipeline/azure-pipelines.yml
+++ b/terraform/pipeline/azure-pipelines.yml
@@ -24,10 +24,10 @@ stages:
               echo "##vso[task.setvariable variable=workspace]$WORKSPACE"
             displayName: Determine deployment environment
             env:
-              REASON: $(Build.Reason)
-              OTHER_SOURCE: $(System.PullRequest.SourceBranch)
-              INDIVIDUAL_SOURCE: $(Build.SourceBranchName)
-              TARGET: $(System.PullRequest.TargetBranch)
+              REASON: $[Build.Reason]
+              OTHER_SOURCE: $[System.PullRequest.SourceBranch]
+              INDIVIDUAL_SOURCE: $[Build.SourceBranchName]
+              TARGET: $[System.PullRequest.TargetBranch]
           # https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformInstaller#readme
           - task: TerraformInstaller@0
             displayName: Install Terraform


### PR DESCRIPTION
Our attempt to handle build reason `IndividualCI` in #175 didn't work because macro syntax variables (`$(blah)`) do not get replaced if there is no replacement variable.

> When the system encounters a macro expression, it replaces the expression with the contents of the variable. If there's no variable by that name, then the macro expression is left unchanged.
([source](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#macro-syntax-variables))

Switch over to runtime expression syntax (`$[blah]`).

> Runtime expression variables silently coalesce to empty strings when a replacement value isn't found.
([source](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#runtime-expression-syntax))

