### PR TITLE
Fix: use runtime expression syntax for variables (with correct syntax)

### DIFF
--- a/terraform/pipeline/azure-pipelines.yml
+++ b/terraform/pipeline/azure-pipelines.yml
@@ -16,6 +16,13 @@ stages:
       vmImage: ubuntu-latest
     jobs:
       - job: plan
+        variables:
+          - name: OTHER_SOURCE
+            value: $[variables['System.PullRequest.SourceBranch']]
+          - name: INDIVIDUAL_SOURCE
+            value: $[variables['Build.SourceBranchName']]
+          - name: TARGET
+            value: $[variables['System.PullRequest.TargetBranch']]
         steps:
           # set the workspace variable at runtime (rather than build time) so that all the necessary variables are available, and we can use Python
           # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=bash#about-tasksetvariable
@@ -24,10 +31,7 @@ stages:
               echo "##vso[task.setvariable variable=workspace]$WORKSPACE"
             displayName: Determine deployment environment
             env:
-              REASON: $[variables['Build.Reason']]
-              OTHER_SOURCE: $[variables['System.PullRequest.SourceBranch']]
-              INDIVIDUAL_SOURCE: $[variables['Build.SourceBranchName']]
-              TARGET: $[variables['System.PullRequest.TargetBranch']]
+              REASON: $(Build.Reason)
           # https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformInstaller#readme
           - task: TerraformInstaller@0
             displayName: Install Terraform

--- a/terraform/pipeline/azure-pipelines.yml
+++ b/terraform/pipeline/azure-pipelines.yml
@@ -24,10 +24,10 @@ stages:
               echo "##vso[task.setvariable variable=workspace]$WORKSPACE"
             displayName: Determine deployment environment
             env:
-              REASON: $[Build.Reason]
-              OTHER_SOURCE: $[System.PullRequest.SourceBranch]
-              INDIVIDUAL_SOURCE: $[Build.SourceBranchName]
-              TARGET: $[System.PullRequest.TargetBranch]
+              REASON: $[variables['Build.Reason']]
+              OTHER_SOURCE: $[variables['System.PullRequest.SourceBranch']]
+              INDIVIDUAL_SOURCE: $[variables['Build.SourceBranchName']]
+              TARGET: $[variables['System.PullRequest.TargetBranch']]
           # https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformInstaller#readme
           - task: TerraformInstaller@0
             displayName: Install Terraform


### PR DESCRIPTION
Similar to #178, but using correct syntax for runtime expressions

Moved runtime expression variables to `variables` block

Put back `REASON` as a macro syntax variable