### PR TITLE
Fix(terraform): availability test

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -26,6 +26,10 @@ resource "azurerm_linux_web_app" "main" {
         ip_address = ip_restriction.value
       }
     }
+
+    ip_restriction {
+      service_tag = "ApplicationInsightsAvailability"
+    }
     vnet_route_all_enabled = true
     application_stack {
       docker_image     = "ghcr.io/cal-itp/eligibility-server"


### PR DESCRIPTION
Merging in #181 caused the availability test to fail. I found some docs saying we could set up service-tag-based access.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service#ip_restriction

> A ip_restriction block supports the following:
> 
>    - [ip_address](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service#ip_address) - (Optional) The IP Address used for this IP Restriction in CIDR notation.
> 
>    - [service_tag](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service#service_tag) - (Optional) The Service Tag used for this IP Restriction.

[Set a service tag-based rule](https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions#set-a-service-tag-based-rule)
[Public test availability enablement](https://learn.microsoft.com/en-us/azure/azure-monitor/app/availability-private-test#public-availability-test-enablement)