### PR TITLE
chore(Azure): split the Key Vault access for engineers from that for the deployer

### DIFF
--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -6,15 +6,30 @@ resource "azurerm_key_vault" "main" {
   sku_name            = "standard"
   tenant_id           = data.azurerm_client_config.current.tenant_id
 
-  # we need this to set secrets through the portal
+  # allow engineers to fully manage secrets
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
+    object_id = var.ENGINEERING_GROUP_ID
 
     secret_permissions = [
+      "Backup",
+      "Delete",
       "Get",
-      "Set",
-      "List"
+      "List",
+      "Purge",
+      "Recover",
+      "Restore",
+      "Set"
+    ]
+  }
+
+  # allow the Pipeline to read secrets
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = var.DEPLOYER_SERVICE_PRINCIPAL_ID
+
+    secret_permissions = [
+      "Get"
     ]
   }
 

--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -9,7 +9,7 @@ resource "azurerm_key_vault" "main" {
   # allow engineers to fully manage secrets
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = var.ENGINEERING_GROUP_ID
+    object_id = var.ENGINEERING_GROUP_OBJECT_ID
 
     secret_permissions = [
       "Backup",
@@ -26,7 +26,7 @@ resource "azurerm_key_vault" "main" {
   # allow the Pipeline to read secrets
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = var.DEPLOYER_SERVICE_PRINCIPAL_ID
+    object_id = var.DEPLOYER_APP_OBJECT_ID
 
     secret_permissions = [
       "Get"

--- a/terraform/pipeline/azure-pipelines.yml
+++ b/terraform/pipeline/azure-pipelines.yml
@@ -44,6 +44,8 @@ stages:
               provider: azurerm
               command: init
               workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
+              # https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform#automated-terraform-cli-workflow
+              commandOptions: -input=false
               # service connection
               backendServiceArm: deployer
               # needs to match main.tf
@@ -68,7 +70,7 @@ stages:
               command: plan
               # wait for lock to be released, in case being used by another pipeline run
               # https://discuss.hashicorp.com/t/terraform-plan-wait-for-lock-to-be-released/6870/2
-              commandOptions: -lock-timeout=2m
+              commandOptions: -input=false -lock-timeout=2m
               workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
               # service connection
               environmentServiceNameAzureRM: deployer
@@ -78,7 +80,7 @@ stages:
               provider: azurerm
               command: apply
               # (ditto the lock comment above)
-              commandOptions: -lock-timeout=2m
+              commandOptions: -input=false -lock-timeout=2m
               workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
               # service connection
               environmentServiceNameAzureRM: deployer

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -4,7 +4,7 @@ resource "azurerm_role_assignment" "velocity_etl" {
   description          = "This role assignment gives write access only for the path of the hashed data file."
   scope                = azurerm_storage_container.config.resource_manager_id
   role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = var.VELOCITY_ETL_SERVICE_PRINCIPAL_ID
+  principal_id         = var.VELOCITY_ETL_APP_OBJECT_ID
   condition            = <<EOF
 (
  (

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,17 +1,17 @@
 # needs to be uppercase "because Azure DevOps will always transform pipeline variables to uppercase environment variables"
 # https://gaunacode.com/terraform-input-variables-using-azure-devops
 
-variable "DEPLOYER_SERVICE_PRINCIPAL_ID" {
-  description = "Object ID from the Azure DevOps deployer service principal in Active Directory"
+variable "DEPLOYER_APP_OBJECT_ID" {
+  description = "Object ID from the Azure DevOps deployer service principal application in Active Directory"
   type        = string
 }
 
-variable "ENGINEERING_GROUP_ID" {
+variable "ENGINEERING_GROUP_OBJECT_ID" {
   description = "Object ID from the engineering group (cal-itp-compiler) in Azure Active Directory"
   type        = string
 }
 
-variable "VELOCITY_ETL_SERVICE_PRINCIPAL_ID" {
+variable "VELOCITY_ETL_APP_OBJECT_ID" {
   description = "Object ID from the registered application for the Velocity server ETL uploading: https://cloudsight.zendesk.com/hc/en-us/articles/360016785598-Azure-finding-your-service-principal-object-ID"
   type        = string
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,6 +1,16 @@
 # needs to be uppercase "because Azure DevOps will always transform pipeline variables to uppercase environment variables"
 # https://gaunacode.com/terraform-input-variables-using-azure-devops
 
+variable "DEPLOYER_SERVICE_PRINCIPAL_ID" {
+  description = "Object ID from the Azure DevOps deployer service principal in Active Directory"
+  type        = string
+}
+
+variable "ENGINEERING_GROUP_ID" {
+  description = "Object ID from the engineering group (cal-itp-compiler) in Azure Active Directory"
+  type        = string
+}
+
 variable "VELOCITY_ETL_SERVICE_PRINCIPAL_ID" {
   description = "Object ID from the registered application for the Velocity server ETL uploading: https://cloudsight.zendesk.com/hc/en-us/articles/360016785598-Azure-finding-your-service-principal-object-ID"
   type        = string


### PR DESCRIPTION
This should keep the Object ID values from changing when we deploy via the Pipeline vs. from our local machines, as seen [here](https://dev.azure.com/mstransit/courtesy-cards/_build/results?buildId=10&view=logs&j=bc150913-bfac-577d-ab97-4eb22da69064&t=9e090432-7346-5314-b3f7-b310ded2d897&l=67). Builds on https://github.com/cal-itp/eligibility-server/pull/183.

- [x] Set new variables in Pipeline
- [ ] Delete `TF_VAR_VELOCITY_ETL_SERVICE_PRINCIPAL_ID`