### PR TITLE
fix(pipeline): use default workspace for prod

### DIFF
--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -17,6 +17,7 @@ printf "Intializing Terraform...\n\n"
 terraform init
 
 printf "\n\nSelecting the Terraform workspace...\n"
+# matching logic in pipeline/workspace.py
 if [ "$ENV" = "prod" ]; then
   terraform workspace select default
 else

--- a/terraform/pipeline/workspace.py
+++ b/terraform/pipeline/workspace.py
@@ -11,13 +11,16 @@ ENV_BRANCHES = ["dev", "test", "prod"]
 
 if REASON == "PullRequest" and TARGET in ENV_BRANCHES:
     # it's a pull request against one of the environment branches, so use the target branch
-    workspace = TARGET
+    environment = TARGET
 elif REASON == "IndividualCI" and SOURCE in ENV_BRANCHES:
     # it's being run on one of the environment branches, so use that
-    workspace = SOURCE
+    environment = SOURCE
 else:
     # default to running against dev
-    workspace = "dev"
+    environment = "dev"
+
+# matching logic in ../init.sh
+workspace = "default" if environment == "prod" else environment
 
 # just for troubleshooting
 if TARGET is not None:


### PR DESCRIPTION
[It was trying to deploy to the `prod` workspace](https://dev.azure.com/mstransit/courtesy-cards/_build/results?buildId=96&view=logs&j=bc150913-bfac-577d-ab97-4eb22da69064&t=0dc68013-2e89-56ea-c92f-d8381195fae6&l=11), when it should be using `default`.