### PR TITLE
Fix: integrity error due to unique constraint on name

### DIFF
--- a/data/server.csv
+++ b/data/server.csv
@@ -2,6 +2,7 @@
 32587,Gonzales,courtesy_card
 03552,McCulley,courtesy_card
 42687,Álvarez,courtesy_card
+65149,Álvarez,courtesy_card
 89768,Muñoz,courtesy_card
 41782,Núñez,courtesy_card
 48727,de Merida,courtesy_card

--- a/eligibility_server/db/models.py
+++ b/eligibility_server/db/models.py
@@ -19,7 +19,7 @@ class Eligibility(db.Model):
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     sub = db.Column(db.String, unique=True, nullable=False)
-    name = db.Column(db.String, unique=True, nullable=False)
+    name = db.Column(db.String, unique=False, nullable=False)
     types = db.relationship("Eligibility", secondary=user_eligibility, lazy="subquery", backref=db.backref("users", lazy=True))
 
     def __repr__(self):

--- a/tests/db/test_setup.py
+++ b/tests/db/test_setup.py
@@ -14,7 +14,7 @@ def test_init_db_command(runner):
 
     assert result.exit_code == 0
 
-    assert User.query.count() == 24
+    assert User.query.count() == 25
     assert Eligibility.query.count() == 1
 
     user_with_one_eligibility = User.query.filter_by(sub="32587", name="Gonzales").first()


### PR DESCRIPTION
It is valid for there to be duplicate values for `name`, as seen in our real data.

The unique constraint on `User.name` is causing an `IntegrityError` when running `flask init-db`:
```
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: user.name
[SQL: INSERT INTO user (sub, name) VALUES (?, ?)]
```

`sub` is the column that should be unique, and it currently has a unique constraint. Let's remove the one on `name`.