### PR TITLE
Chore(test): remove deprecated algorithm

### DIFF
--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -12,15 +12,11 @@ test_data = [
         "sha512",
         "c6ee9e33cf5c6715a1d148fd73f7318884b41adcb916021e2bc0e800a5c5dd97f5142178f6ae88c8fdd98e1afb0ce4c8d2c54b5f37b30b7da1997bb33b0b8a31",  # noqa: E501
     ),
-    (
-        "whirlpool",
-        "ac1c196e84b05d59faea639d0cccb6c16f7568e0943f4c94c648bd8eefe5cf3978f8d4f99b1426e4ce3c6fa40e17cf68d6b86d42246333569b963ff4579c6355",  # noqa: E501
-    ),
 ]
 
 
 def test_hash_init():
-    assert Hash("whirlpool")._input_hash_algo == "whirlpool"
+    assert Hash("sha512")._input_hash_algo == "sha512"
 
 
 def test_hash_init_invalid_type():


### PR DESCRIPTION
Our pytest check has been failing (e.g. the [one](https://github.com/cal-itp/eligibility-server/actions/runs/3499759820/jobs/5861669208) for #205)

@thekaveman found https://github.com/python/cpython/issues/91257, which says:

> The hashlib.algorithms_available set includes algorithms like ripemd160 and whirlpool, those algorithms are not usable unless openssl legacy provider is loaded. Since it's not loaded, and the hashlib module won't load it, any attempt to use them fails.

We'll remove `whirlpool` from our test cases.