### PR TITLE
Fix(terraform): downgrade app service plan

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -3,7 +3,7 @@ resource "azurerm_service_plan" "main" {
   location            = data.azurerm_resource_group.main.location
   resource_group_name = data.azurerm_resource_group.main.name
   os_type             = "Linux"
-  sku_name            = "P2v2"
+  sku_name            = "B1"
 }
 
 locals {


### PR DESCRIPTION
Closes #200 

This PR downgrades the app service plan to Basic. From Microsoft's [App Service Plan pricing](https://azure.microsoft.com/en-us/pricing/details/app-service/windows/#pricing):
> ### Basic Service Plan
>
>The Basic service plan is designed for apps that have lower traffic requirements, and don't need advanced auto scale and traffic management features. Pricing is based on the size and number of instances you run. Built-in network load balancing support automatically distributes traffic across instances. The Basic service plan with Linux runtime environments supports [Web App for Containers](https://docs.microsoft.com/en-us/azure/app-service/containers/app-service-linux-intro).

The docs for [azurerm_service_plan.sku_name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan#sku_name) specify the possible values and match what's listed in the pricing table.

We can always [scale up](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans#what-if-my-app-needs-more-capabilities-or-features) if we find we're missing features.
> You can choose a lower pricing tier at first and scale up later when you need more App Service features.