### PR TITLE
Feat(Terraform): front door

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -28,6 +28,12 @@ All resources in these Resource Groups should be reflected in Terraform in this 
 
 For browsing the [Azure portal](https://portal.azure.com), you can [switch your `Default subscription filter`](https://docs.microsoft.com/en-us/azure/azure-portal/set-preferences).
 
+## Access restrictions
+
+We restrict which IP addresses that can access the app service by using a Web Application Firewall (WAF) configured on a Front Door. There is an exception for the `/healthcheck` path, which can be accessed by any IP address.
+
+The app service itself gives access only to our Front Door and to Azure availability tests.
+
 ## Monitoring
 
 We have [ping tests](https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability) set up to notify about availability of each environment. Alerts go to [#benefits-notify](https://cal-itp.slack.com/archives/C022HHSEE3F).

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -23,6 +23,24 @@ resource "azurerm_linux_web_app" "main" {
     http2_enabled = true
 
     vnet_route_all_enabled = true
+
+    ip_restriction {
+      name        = "Front Door"
+      priority    = 100
+      action      = "Allow"
+      service_tag = "AzureFrontDoor.Backend"
+      headers {
+        x_azure_fdid = [azurerm_cdn_frontdoor_profile.main.resource_guid]
+      }
+    }
+
+    ip_restriction {
+      name        = "Availability Test"
+      priority    = 200
+      action      = "Allow"
+      service_tag = "ApplicationInsightsAvailability"
+    }
+
     application_stack {
       docker_image     = "ghcr.io/cal-itp/eligibility-server"
       docker_image_tag = local.env_name

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -22,12 +22,6 @@ resource "azurerm_linux_web_app" "main" {
     ftps_state    = "Disabled"
     http2_enabled = true
 
-    dynamic "ip_restriction" {
-      for_each = var.IP_ADDRESS_WHITELIST
-      content {
-        ip_address = ip_restriction.value
-      }
-    }
     vnet_route_all_enabled = true
     application_stack {
       docker_image     = "ghcr.io/cal-itp/eligibility-server"

--- a/terraform/environment.tf
+++ b/terraform/environment.tf
@@ -1,5 +1,6 @@
 locals {
   is_prod  = terraform.workspace == "default"
+  is_test  = terraform.workspace == "test"
   env_name = local.is_prod ? "prod" : terraform.workspace
 }
 

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -82,8 +82,8 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "main" {
 
     match_condition {
       match_variable = "RequestUri"
-      operator       = "EndsWith"
-      match_values   = ["/healthcheck"]
+      operator       = "Equals"
+      match_values   = ["https://${azurerm_cdn_frontdoor_endpoint.main.host_name}:443/healthcheck"]
     }
   }
 

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -72,10 +72,24 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "main" {
   custom_block_response_body        = base64encode("Blocked")
 
   custom_rule {
-    name     = "iprestriction${local.env_name}"
+    name     = "healthcheck"
     enabled  = true
     type     = "MatchRule"
     priority = 1
+    action   = "Allow"
+
+    match_condition {
+      match_variable = "RequestUri"
+      operator       = "EndsWith"
+      match_values   = ["/healthcheck"]
+    }
+  }
+
+  custom_rule {
+    name     = "iprestriction${local.env_name}"
+    enabled  = true
+    type     = "MatchRule"
+    priority = 2
     action   = "Block"
 
     match_condition {

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -18,6 +18,8 @@ resource "azurerm_cdn_frontdoor_origin_group" "main" {
   name                     = local.front_door_name
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.main.id
 
+  # this block is required, and it's empty because we are fine with using the default values
+  # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin_group#load_balancing
   load_balancing {}
 }
 

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -17,7 +17,6 @@ resource "azurerm_cdn_frontdoor_endpoint" "main" {
 resource "azurerm_cdn_frontdoor_origin_group" "main" {
   name                     = local.front_door_name
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.main.id
-  session_affinity_enabled = true
 
   load_balancing {}
 }

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -69,7 +69,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "main" {
   enabled                           = true
   mode                              = "Prevention"
   custom_block_response_status_code = 403
-  custom_block_response_body        = base64encode("Blocked")
+  custom_block_response_body        = base64encode("Forbidden")
 
   custom_rule {
     name     = "healthcheck"

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -27,11 +27,8 @@ resource "azurerm_cdn_frontdoor_origin" "main" {
 
   enabled                        = true
   host_name                      = azurerm_linux_web_app.main.default_hostname
-  http_port                      = 80
-  https_port                     = 443
   origin_host_header             = azurerm_linux_web_app.main.default_hostname
   certificate_name_check_enabled = true
-  priority                       = 1
   weight                         = 1000
 }
 

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -1,0 +1,51 @@
+locals {
+  front_door_origin_group_name = azurerm_linux_web_app.main.name
+  front_door_origin_name       = azurerm_linux_web_app.main.name
+  front_door_route_name        = azurerm_linux_web_app.main.name
+}
+
+resource "azurerm_cdn_frontdoor_profile" "main" {
+  name                = "mst-courtesy-cards-${local.env_name}"
+  resource_group_name = data.azurerm_resource_group.main.name
+  sku_name            = "Standard_AzureFrontDoor"
+}
+
+resource "azurerm_cdn_frontdoor_endpoint" "main" {
+  name                     = "frontdoor-endpoint-${local.env_name}"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.main.id
+}
+
+resource "azurerm_cdn_frontdoor_origin_group" "main" {
+  name                     = local.front_door_origin_group_name
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.main.id
+  session_affinity_enabled = true
+
+  load_balancing {}
+}
+
+resource "azurerm_cdn_frontdoor_origin" "main" {
+  name                          = local.front_door_origin_name
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.main.id
+
+  enabled                        = true
+  host_name                      = azurerm_linux_web_app.main.default_hostname
+  http_port                      = 80
+  https_port                     = 443
+  origin_host_header             = azurerm_linux_web_app.main.default_hostname
+  certificate_name_check_enabled = true
+  priority                       = 1
+  weight                         = 1000
+}
+
+resource "azurerm_cdn_frontdoor_route" "main" {
+  name                          = local.front_door_route_name
+  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.main.id
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.main.id
+  cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.main.id]
+
+  https_redirect_enabled = true
+  supported_protocols    = ["Http", "Https"]
+  patterns_to_match      = ["/*"]
+  forwarding_protocol    = "HttpsOnly"
+  link_to_default_domain = true
+}

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -1,22 +1,21 @@
 locals {
-  front_door_origin_group_name = azurerm_linux_web_app.main.name
-  front_door_origin_name       = azurerm_linux_web_app.main.name
-  front_door_route_name        = azurerm_linux_web_app.main.name
+  front_door_name = "eligibility-server-${local.env_name}"
 }
 
 resource "azurerm_cdn_frontdoor_profile" "main" {
-  name                = "mst-courtesy-cards-${local.env_name}"
+  name                = local.front_door_name
   resource_group_name = data.azurerm_resource_group.main.name
   sku_name            = "Standard_AzureFrontDoor"
 }
 
 resource "azurerm_cdn_frontdoor_endpoint" "main" {
-  name                     = "frontdoor-endpoint-${local.env_name}"
+  # used in the front door URL
+  name                     = "mst-courtesy-cards-eligibility-server-${local.env_name}"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.main.id
 }
 
 resource "azurerm_cdn_frontdoor_origin_group" "main" {
-  name                     = local.front_door_origin_group_name
+  name                     = local.front_door_name
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.main.id
   session_affinity_enabled = true
 
@@ -24,7 +23,7 @@ resource "azurerm_cdn_frontdoor_origin_group" "main" {
 }
 
 resource "azurerm_cdn_frontdoor_origin" "main" {
-  name                          = local.front_door_origin_name
+  name                          = local.front_door_name
   cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.main.id
 
   enabled                        = true
@@ -38,7 +37,7 @@ resource "azurerm_cdn_frontdoor_origin" "main" {
 }
 
 resource "azurerm_cdn_frontdoor_route" "main" {
-  name                          = local.front_door_route_name
+  name                          = local.front_door_name
   cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.main.id
   cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.main.id
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.main.id]

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -86,7 +86,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "main" {
       match_variable     = "SocketAddr"
       operator           = "Contains"
       negation_condition = true
-      match_values       = var.IP_ADDRESS_WHITELIST
+      match_values       = local.is_prod ? var.IP_ADDRESS_WHITELIST_PROD : local.is_test ? var.IP_ADDRESS_WHITELIST_TEST : var.IP_ADDRESS_WHITELIST_DEV
     }
   }
 }

--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -1,3 +1,4 @@
+# when setting up access restrictions, make sure to allow the ApplicationInsightsAvailability service tag
 module "healthcheck" {
   source = "./uptime"
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,7 +16,19 @@ variable "VELOCITY_ETL_APP_OBJECT_ID" {
   type        = string
 }
 
-variable "IP_ADDRESS_WHITELIST" {
+variable "IP_ADDRESS_WHITELIST_DEV" {
+  description = "List of IP addresses allowed to connect to the app service, in CIDR notation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app#ip_address. By default, all IP addresses are allowed."
+  type        = list(string)
+  default     = []
+}
+
+variable "IP_ADDRESS_WHITELIST_TEST" {
+  description = "List of IP addresses allowed to connect to the app service, in CIDR notation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app#ip_address. By default, all IP addresses are allowed."
+  type        = list(string)
+  default     = []
+}
+
+variable "IP_ADDRESS_WHITELIST_PROD" {
   description = "List of IP addresses allowed to connect to the app service, in CIDR notation: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app#ip_address. By default, all IP addresses are allowed."
   type        = list(string)
   default     = []


### PR DESCRIPTION
Closes #208 

This PR sets up a Front Door with a WAF policy to allow only a certain list of IP addresses.

Note there is some overlap with #213 since the whitelist is different per-environment.

### Before merging:
 - [x] Clean up manually created Front Door resources that were used to get a working configuration
 - [x] Set `TF_VAR_IP_ADDRESS_WHITELIST_DEV` variable in Azure pipeline
 
### After merging:
 - [ ] Update Benefits dev data migration to use front-door hostname in `EligibilityVerifier` API URL

### Some reference material
- [Configure an IP restriction rule with a Web Application Firewall for Azure Front Door](https://learn.microsoft.com/en-us/azure/web-application-firewall/afds/waf-front-door-configure-ip-restriction)
- [Secure traffic to Azure Front Door origins](https://learn.microsoft.com/en-us/azure/frontdoor/origin-security?tabs=app-service-functions&pivots=front-door-standard-premium)
- [Best practices for Front Door](https://learn.microsoft.com/en-us/azure/frontdoor/best-practices)
- [Best practices for Web Application Firewall (WAF) on Azure Front Door](https://learn.microsoft.com/en-us/azure/web-application-firewall/afds/waf-front-door-best-practices)