### PR TITLE
fix(terraform): typo in custom rule operator

### DIFF
--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -82,7 +82,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "main" {
 
     match_condition {
       match_variable = "RequestUri"
-      operator       = "Equals"
+      operator       = "Equal"
       match_values   = ["https://${azurerm_cdn_frontdoor_endpoint.main.host_name}:443/healthcheck"]
     }
   }


### PR DESCRIPTION
Follow-up to #222 

I didn't catch this typo, and neither did the [`terraform plan`](https://dev.azure.com/mstransit/courtesy-cards/_build/results?buildId=133&view=logs&j=e2b2897c-f736-5615-5c9c-c20ddcd4aa73&t=64d2c667-b30c-5507-42a1-d7f546f77724&l=80) from our pipeline. The `terraform apply` when merging in #222 [showed the error](https://dev.azure.com/mstransit/courtesy-cards/_build/results?buildId=135&view=logs&j=e2b2897c-f736-5615-5c9c-c20ddcd4aa73&t=ce99383a-5c73-5e0e-b029-4934b8ac07e5&l=272) though.