### PR TITLE
Fix: IP restriction custom rule

### DIFF
--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -96,7 +96,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "main" {
 
     match_condition {
       match_variable     = "SocketAddr"
-      operator           = "Contains"
+      operator           = "IPMatch"
       negation_condition = true
       match_values       = local.is_prod ? var.IP_ADDRESS_WHITELIST_PROD : local.is_test ? var.IP_ADDRESS_WHITELIST_TEST : var.IP_ADDRESS_WHITELIST_DEV
     }

--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -57,7 +57,7 @@ resource "azurerm_cdn_frontdoor_security_policy" "main" {
       association {
         patterns_to_match = ["/*"]
         domain {
-          cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_endpoint.main.host_name
+          cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_endpoint.main.id
         }
       }
     }


### PR DESCRIPTION
One more follow-up to #222 

A few more errors seen when running `terraform apply` (ran locally):
 - `"Match Variable SocketAddr must be used with Operator(s) Any,IPMatch,GeoMatch"`
 - `"domain" is invalid: the "security_policies.0.firewall.0.association.0.domain.0.cdn_frontdoor_domain_id" needs to be a valid CDN Front Door Custom Domain ID or a valid CDN Front Door Endpoint ID`

Fixed these two, and then saw a successful `terraform apply`.