### PR TITLE
Refactor: use eligibility-api

### DIFF
--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -47,8 +47,7 @@ def healthcheck():
 def publickey():
     app.logger.info("Request public key")
     key = get_server_public_key()
-    pem_data = key.export_to_pem(private_key=False)
-    return TextResponse(pem_data.decode("utf-8"))
+    return TextResponse(key.decode("utf-8"))
 
 
 @app.errorhandler(401)

--- a/eligibility_server/keypair.py
+++ b/eligibility_server/keypair.py
@@ -1,6 +1,5 @@
 import logging
 
-from jwcrypto import jwk
 import requests
 
 from eligibility_server.settings import Configuration
@@ -19,10 +18,10 @@ def _read_key_file(key_path):
 
     if key_path.startswith("http"):
         data = requests.get(key_path).text
-        key = jwk.JWK.from_pem(data.encode("utf8"))
+        key = data.encode("utf8")
     else:
         with open(key_path, "rb") as pemfile:
-            key = jwk.JWK.from_pem(pemfile.read())
+            key = pemfile.read()
 
     _CACHE[key_path] = key
 

--- a/eligibility_server/verify.py
+++ b/eligibility_server/verify.py
@@ -9,7 +9,7 @@ import re
 
 from flask import abort
 from flask_restful import Resource, reqparse
-from jwcrypto import jwe, jws, jwt
+from jwcrypto import jwe, jwk, jws, jwt
 
 from eligibility_server import keypair
 from eligibility_server.db.models import User
@@ -24,8 +24,8 @@ logger = logging.getLogger(__name__)
 class Verify(Resource):
     def __init__(self):
         """Initialize Verify class with a keypair and hash"""
-        self.client_public_key = keypair.get_client_public_key()
-        self.server_private_key = keypair.get_server_private_key()
+        self.client_public_key = jwk.JWK.from_pem(keypair.get_client_public_key())
+        self.server_private_key = jwk.JWK.from_pem(keypair.get_server_private_key())
 
         if config.input_hash_algo != "":
             hash = Hash(config.input_hash_algo)

--- a/eligibility_server/verify.py
+++ b/eligibility_server/verify.py
@@ -3,13 +3,12 @@ Eligibility Verification route
 """
 
 import datetime
-import json
 import logging
 import re
 
+from eligibility_api.server import get_token_payload, make_token
 from flask import abort
 from flask_restful import Resource, reqparse
-from jwcrypto import jwe, jwk, jws, jwt
 
 from eligibility_server import keypair
 from eligibility_server.db.models import User
@@ -24,8 +23,8 @@ logger = logging.getLogger(__name__)
 class Verify(Resource):
     def __init__(self):
         """Initialize Verify class with a keypair and hash"""
-        self.client_public_key = jwk.JWK.from_pem(keypair.get_client_public_key())
-        self.server_private_key = jwk.JWK.from_pem(keypair.get_server_private_key())
+        self.client_public_key = keypair.get_client_public_key()
+        self.server_private_key = keypair.get_server_private_key()
 
         if config.input_hash_algo != "":
             hash = Hash(config.input_hash_algo)
@@ -60,36 +59,6 @@ class Verify(Resource):
             logger.warning("Invalid token format")
             raise ValueError("Invalid token format")
 
-    def _get_token_payload(self, token):
-        """Decode a token (JWE(JWS))."""
-        try:
-            # decrypt
-            decrypted_token = jwe.JWE(algs=[config.jwe_encryption_alg, config.jwe_cek_enc])
-            decrypted_token.deserialize(token, key=self.server_private_key)
-            decrypted_payload = str(decrypted_token.payload, "utf-8")
-            # verify signature
-            signed_token = jws.JWS()
-            signed_token.deserialize(decrypted_payload, key=self.client_public_key, alg=config.jws_signing_alg)
-            # return final payload
-            payload = str(signed_token.payload, "utf-8")
-            return json.loads(payload)
-        except Exception:
-            logger.warning("Get token payload failed")
-            return False
-
-    def _make_token(self, payload):
-        """Wrap payload in a signed and encrypted JWT for response."""
-        # sign the payload with server's private key
-        header = {"typ": "JWS", "alg": config.jws_signing_alg}
-        signed_token = jwt.JWT(header=header, claims=payload)
-        signed_token.make_signed_token(self.server_private_key)
-        signed_payload = signed_token.serialize()
-        # encrypt the signed payload with client's public key
-        header = {"typ": "JWE", "alg": config.jwe_encryption_alg, "enc": config.jwe_cek_enc}
-        encrypted_token = jwt.JWT(header=header, claims=signed_payload)
-        encrypted_token.make_encrypted_token(self.client_public_key)
-        return encrypted_token.serialize()
-
     def _get_response(self, token_payload):
         try:
             # craft the response payload using parsed request token
@@ -107,8 +76,16 @@ class Verify(Resource):
             else:
                 resp_payload["error"] = {"sub": "invalid"}
                 code = 400
-            # make a response token with appropriate response code
-            return self._make_token(resp_payload), code
+            # make a response token, and return with appropriate response code
+            response_token = make_token(
+                payload=resp_payload,
+                jws_signing_alg=config.jws_signing_alg,
+                server_private_key=self.server_private_key,
+                jwe_encryption_alg=config.jwe_encryption_alg,
+                jwe_cek_enc=config.jwe_cek_enc,
+                client_public_key=self.client_public_key,
+            )
+            return response_token, code
         except (TypeError, ValueError) as ex:
             logger.error(f"Error: {ex}")
             abort(400, description="Bad request")
@@ -167,7 +144,14 @@ class Verify(Resource):
         # parse inner payload from request token
         try:
             token = self._get_token(headers)
-            token_payload = self._get_token_payload(token)
+            token_payload = get_token_payload(
+                token=token,
+                jwe_encryption_alg=config.jwe_encryption_alg,
+                jwe_cek_enc=config.jwe_cek_enc,
+                server_private_key=self.server_private_key,
+                jws_signing_alg=config.jws_signing_alg,
+                client_public_key=self.client_public_key,
+            )
         except Exception:
             logger.error("Bad request")
             abort(400, description="Bad request")

--- a/eligibility_server/verify.py
+++ b/eligibility_server/verify.py
@@ -2,11 +2,10 @@
 Eligibility Verification route
 """
 
-import datetime
 import logging
 import re
 
-from eligibility_api.server import get_token_payload, make_token
+from eligibility_api.server import get_token_payload, make_token, create_response_payload
 from flask import abort
 from flask_restful import Resource, reqparse
 
@@ -63,11 +62,7 @@ class Verify(Resource):
         try:
             # craft the response payload using parsed request token
             sub, name, eligibility = token_payload["sub"], token_payload["name"], list(token_payload["eligibility"])
-            resp_payload = dict(
-                jti=token_payload["jti"],
-                iss=config.app_name,
-                iat=int(datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).timestamp()),
-            )
+            resp_payload = create_response_payload(token_payload=token_payload, issuer=config.app_name)
             # sub format check
             if re.match(config.sub_format_regex, sub):
                 # eligibility check against db

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ git+https://github.com/cal-itp/eligibility-api#egg=eligibility_api
 Flask==2.2.2
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==3.0.2
-jwcrypto==1.4.2
 requests==2.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cryptography==38.0.3
 git+https://github.com/cal-itp/eligibility-api#egg=eligibility_api
 Flask==2.2.2
 Flask-RESTful==0.3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-cryptography==38.0.4
+cryptography==38.0.3
+git+https://github.com/cal-itp/eligibility-api#egg=eligibility_api
 Flask==2.2.2
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==3.0.2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,9 @@ from setuptools import find_packages, setup
 
 
 with open("requirements.txt") as f:
-    install_requires = f.read().strip().split("\n")
+    requirements = f.read().strip().split("\n")
+    install_requires = [r for r in requirements if not r.startswith("git+")]
+    dependency_links = list(set(requirements) - set(install_requires))
 
 with open("README.md") as f:
     long_description = f.read()
@@ -30,5 +32,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=install_requires,
+    dependency_links=dependency_links,
     license="AGPL-3.0",
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
 coverage
-jwcrypto==1.4.2
 pytest
 pytest-mock

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 coverage
+jwcrypto==1.4.2
 pytest
 pytest-mock

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,4 +30,4 @@ def test_publickey(client):
     response = client.get("publickey")
     assert response.status_code == 200
     assert response.mimetype == "text/plain"
-    assert response.text == get_server_public_key().export_to_pem().decode("utf-8")
+    assert response.text == get_server_public_key().decode("utf-8")

--- a/tests/test_keypair.py
+++ b/tests/test_keypair.py
@@ -2,6 +2,7 @@ import builtins
 
 import pytest
 import requests
+from jwcrypto import jwk
 
 from eligibility_server import keypair
 from eligibility_server.keypair import _read_key_file
@@ -34,7 +35,7 @@ def spy_requests_get(mocker):
 
 @pytest.mark.usefixtures("reset_cache")
 def test_read_key_file_local(mocker, sample_key_path_local, spy_open):
-    key = _read_key_file(sample_key_path_local)
+    key = jwk.JWK.from_pem(_read_key_file(sample_key_path_local))
 
     # check that there was a call to open the default path
     assert mocker.call(sample_key_path_local, "rb") in spy_open.call_args_list
@@ -45,7 +46,7 @@ def test_read_key_file_local(mocker, sample_key_path_local, spy_open):
 
 @pytest.mark.usefixtures("reset_cache")
 def test_read_key_file_remote(sample_key_path_remote, spy_open, spy_requests_get):
-    key = _read_key_file(sample_key_path_remote)
+    key = jwk.JWK.from_pem(_read_key_file(sample_key_path_remote))
 
     # check that there was no call to open
     assert spy_open.call_count == 0

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -18,7 +18,7 @@ def test_Verify_client_get_bad_request(mocker, client):
     mocked_headers = {"TOKEN_HEADER": "blah"}
     mocker.patch("eligibility_server.verify.Verify._check_headers", return_value=mocked_headers)
     mocker.patch("eligibility_server.verify.Verify._get_token", return_value="token")
-    mocker.patch("eligibility_server.verify.Verify._get_token_payload", return_value="bad token")
+    mocker.patch("eligibility_server.verify.get_token_payload", return_value="bad token")
     response = client.get("/verify", json=token_payload)
 
     assert response.status_code == 400


### PR DESCRIPTION
Closes #38 

This PR makes the minimal changes needed for eligibility-server to use the eligibility-api.
It also removes `jwcrypto` from the app container's dependencies.

### Rebuilding
Make sure to run
```
./bin/build.sh
```
before re-opening the devcontainer so that these changes to the app container's `requirements.txt` are used.