### PR TITLE
Chore: use eligibility-api package from PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/cal-itp/eligibility-api#egg=eligibility_api
+eligibility-api==2023.01.1
 Flask==2.2.2
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==3.0.2


### PR DESCRIPTION
Similar to cal-itp/benefits#1182, this PR switches our app container from using the eligibility-api GitHub repo to using the [package published on PyPI](https://pypi.org/project/eligibility-api).