### PR TITLE
fix(Azure): suppress downtime alerts when data is being loaded

### DIFF
--- a/terraform/suppress.arm.json
+++ b/terraform/suppress.arm.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "metricAlertID": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.AlertsManagement/actionRules",
+      "apiVersion": "2021-08-08",
+      "name": "suppress-nightly-downtime",
+      "location": "Global",
+      "properties": {
+        "description": "Suppresses alerts during the scheduled nightly downtime",
+        "scopes": ["[parameters('metricAlertID')]"],
+        "actions": [
+          {
+            "actionType": "RemoveAllActionGroups"
+          }
+        ],
+        "schedule": {
+          "timeZone": "Eastern Standard Time",
+          "recurrences": [
+            {
+              "recurrenceType": "Daily",
+              "startTime": "06:00:00",
+              "endTime": "06:10:00"
+            }
+          ]
+        },
+        "enabled": true
+      }
+    }
+  ]
+}

--- a/terraform/uptime.tf
+++ b/terraform/uptime.tf
@@ -8,3 +8,27 @@ module "healthcheck" {
   name = "mst-courtesy-cards-eligibility-server-${local.env_name}-healthcheck"
   url  = "https://${azurerm_linux_web_app.main.default_hostname}/healthcheck"
 }
+
+# ignore when app restarts as data is being reloaded
+# https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-processing-rules
+resource "azurerm_monitor_action_rule_suppression" "suppression" {
+  name                = "ignore-data-loading"
+  resource_group_name = data.azurerm_resource_group.main.name
+
+  scope {
+    type         = "Resource"
+    resource_ids = [module.healthcheck.metric_alert_id]
+
+  }
+
+  suppression {
+    recurrence_type = "Daily"
+
+    schedule {
+      start_date_utc = "2020-01-01T00:00:00Z"
+      end_date_utc   = "2050-01-01T00:00:00Z"
+      start_time_utc = "11:00AM"
+      end_time_utc   = "11:10AM"
+    }
+  }
+}

--- a/terraform/uptime/outputs.tf
+++ b/terraform/uptime/outputs.tf
@@ -1,0 +1,3 @@
+output "metric_alert_id" {
+  value = azurerm_monitor_metric_alert.uptime.id
+}


### PR DESCRIPTION
Fixes https://github.com/cal-itp/eligibility-server/issues/220.

Uses an [alert processing rule](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-processing-rules) to disable notifications during that specific window of time every night.