### PR TITLE
fix(alerts): expand nightly downtime window

### DIFF
--- a/terraform/suppress.arm.json
+++ b/terraform/suppress.arm.json
@@ -26,7 +26,7 @@
             {
               "recurrenceType": "Daily",
               "startTime": "06:00:00",
-              "endTime": "06:10:00"
+              "endTime": "06:20:00"
             }
           ]
         },


### PR DESCRIPTION
Seeing it happen slightly later:

https://cal-itp.slack.com/files/USLACKBOT/F04RLRXC1QS/azure_monitor_alert_activated_for_your_availability_test__mst-courtesy-cards-eligibility-server-test-healthcheck__with_severity_1