### PR TITLE
Feat: Sentry error monitoring

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,7 @@
 FLASK_APP=eligibility_server/app.py
+
+# this sample uses an odd relative path because the value is
+# used by code under the eligibility_server directory
+# and thus the config folder is one level up
+
 ELIGIBILITY_SERVER_SETTINGS=../config/sample.py

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -133,3 +133,27 @@ These are the possible values for the `CSV_QUOTING` variable:
 - `csv.QUOTE_ALL`: 1 - To be used when all the values in the CSV file are present inside quotation marks
 - `csv.QUOTE_NONNUMERIC`: 2 - To be used when the CSV file uses quotes around non-numeric entries
 - `csv.QUOTE_NONE`: 3 - To be used when the CSV file does not use quotes around entries
+
+## Sentry
+
+### `SENTRY_DSN`
+
+Cal-ITP's Sentry instance collects both [errors ("Issues")](https://sentry.calitp.org/organizations/sentry/issues/?project=4) and app [performance info](https://sentry.calitp.org/organizations/sentry/performance/?project=4).
+
+[Alerts are sent to #benefits-notify in Slack.](https://sentry.calitp.org/organizations/sentry/alerts/rules/eligibility-server/10/details/) [Others can be configured.](https://sentry.calitp.org/organizations/sentry/alerts/rules/)
+
+You can troubleshoot Sentry itself by [turning on debug mode](#debug_mode) and visiting `/error/`.
+
+!!! tldr "Sentry docs"
+
+    [Data Source Name (DSN)](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)
+
+Enables sending events to Sentry.
+
+### `SENTRY_ENVIRONMENT`
+
+!!! tldr "Sentry docs"
+
+    [`environment` config value](https://docs.sentry.io/platforms/python/configuration/options/#environment)
+
+Segments errors by which deployment they occur in. This defaults to `local`, and can be set to match one of the environment names.

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -6,6 +6,10 @@ The sections below outline in more detail the settings that you either must set 
 
 ## App settings
 
+### `AGENCY_NAME`
+
+The name of the agency that this server is deployed for
+
 ### `APP_NAME`
 
 The name set on the Flask app

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -161,3 +161,13 @@ Enables sending events to Sentry.
     [`environment` config value](https://docs.sentry.io/platforms/python/configuration/options/#environment)
 
 Segments errors by which deployment they occur in. This defaults to `local`, and can be set to match one of the environment names.
+
+### `SENTRY_TRACES_SAMPLE_RATE`
+
+!!! tldr "Sentry docs"
+
+    [`traces_sample_rate` config value](https://docs.sentry.io/platforms/python/configuration/options/#traces-sample-rate)
+
+Control the volume of transactions sent to Sentry. Value must be a float in the range `[0.0, 1.0]`.
+
+The default is `0.0` (i.e. no transactions are tracked).

--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -41,7 +41,7 @@ def TextResponse(content):
 with app.app_context():
     if config.debug_mode:
 
-        @app.route("/sentry-debug")
+        @app.route("/error")
         def trigger_error():
             raise ValueError("testing Sentry for eligibility-server")
 

--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -15,8 +15,6 @@ from eligibility_server.verify import Verify
 
 config = Configuration()
 
-sentry.configure()
-
 app = Flask(__name__)
 app.config.from_object("eligibility_server.settings")
 app.config.from_envvar("ELIGIBILITY_SERVER_SETTINGS", silent=True)
@@ -25,6 +23,7 @@ format_string = "[%(asctime)s] %(levelname)s %(name)s:%(lineno)s %(message)s"
 
 # use an app context for access to config settings
 with app.app_context():
+    sentry.configure(config)
     # configure root logger first, to prevent duplicate log entries from Flask's logger
     logging.basicConfig(level=config.log_level, format=format_string)
     # configure Flask's logger

--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -38,6 +38,14 @@ def TextResponse(content):
     return response
 
 
+with app.app_context():
+    if config.debug_mode:
+
+        @app.route("/sentry-debug")
+        def trigger_error():
+            raise ValueError("testing Sentry for eligibility-server")
+
+
 @app.route("/healthcheck")
 def healthcheck():
     app.logger.info("Request healthcheck")

--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -7,13 +7,15 @@ from flask import Flask, jsonify, make_response
 from flask_restful import Api
 from flask.logging import default_handler
 
-from eligibility_server import db
+from eligibility_server import db, sentry
 from eligibility_server.keypair import get_server_public_key
 from eligibility_server.settings import Configuration
 from eligibility_server.verify import Verify
 
 
 config = Configuration()
+
+sentry.configure()
 
 app = Flask(__name__)
 app.config.from_object("eligibility_server.settings")

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 
@@ -6,6 +7,8 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.scrubber import EventScrubber, DEFAULT_DENYLIST
 
 from eligibility_server.settings import Configuration
+
+logger = logging.getLogger(__name__)
 
 
 SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
@@ -30,7 +33,7 @@ def configure(config: Configuration):
     SENTRY_DSN = config.sentry_dsn
     if SENTRY_DSN:
         release = get_release()
-        print(f"Enabling Sentry for environment '{SENTRY_ENVIRONMENT}', release '{release}'...")
+        logger.info(f"Enabling Sentry for environment '{SENTRY_ENVIRONMENT}', release '{release}'...")
 
         sentry_sdk.init(
             dsn=SENTRY_DSN,
@@ -47,4 +50,4 @@ def configure(config: Configuration):
             event_scrubber=EventScrubber(denylist=get_denylist()),
         )
     else:
-        print("SENTRY_DSN not set, so won't send events")
+        logger.warning("SENTRY_DSN not set, so won't send events")

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -1,0 +1,14 @@
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+
+
+def configure():
+    sentry_sdk.init(
+        integrations=[
+            FlaskIntegration(),
+        ],
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        # We recommend adjusting this value in production.
+        traces_sample_rate=1.0,
+    )

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -60,5 +60,7 @@ def configure(config: Configuration):
             send_default_pii=False,
             event_scrubber=EventScrubber(denylist=get_denylist()),
         )
+
+        sentry_sdk.set_tag("agency_name", config.agency_name)
     else:
         logger.warning("SENTRY_DSN not set, so won't send events")

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -1,14 +1,21 @@
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 
+from eligibility_server.settings import Configuration
 
-def configure():
-    sentry_sdk.init(
-        integrations=[
-            FlaskIntegration(),
-        ],
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for performance monitoring.
-        # We recommend adjusting this value in production.
-        traces_sample_rate=1.0,
-    )
+
+def configure(config: Configuration):
+    SENTRY_DSN = config.sentry_dsn
+    if SENTRY_DSN:
+        sentry_sdk.init(
+            dsn=SENTRY_DSN,
+            integrations=[
+                FlaskIntegration(),
+            ],
+            # Set traces_sample_rate to 1.0 to capture 100%
+            # of transactions for performance monitoring.
+            # We recommend adjusting this value in production.
+            traces_sample_rate=1.0,
+        )
+    else:
+        print("SENTRY_DSN not set, so won't send events")

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import subprocess
 
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -9,9 +11,32 @@ from eligibility_server.settings import Configuration
 SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
 
 
+def git_available():
+    return bool(shutil.which("git"))
+
+
+# https://stackoverflow.com/a/24584384/358804
+def is_git_directory(path="."):
+    dev_null = open(os.devnull, "w")
+    return subprocess.call(["git", "-C", path, "status"], stderr=dev_null, stdout=dev_null) == 0
+
+
+# https://stackoverflow.com/a/21901260/358804
+def get_git_revision_hash():
+    return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
+
+
+def get_release() -> str:
+    """Returns the first available: the SHA from Git, the value from sha.txt, or the VERSION."""
+    return get_git_revision_hash()
+
+
 def configure(config: Configuration):
     SENTRY_DSN = config.sentry_dsn
     if SENTRY_DSN:
+        release = get_release()
+        print(f"Enabling Sentry for environment '{SENTRY_ENVIRONMENT}', release '{release}'...")
+
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             integrations=[
@@ -19,6 +44,7 @@ def configure(config: Configuration):
             ],
             traces_sample_rate=1.0,
             environment=SENTRY_ENVIRONMENT,
+            release=release,
         )
     else:
         print("SENTRY_DSN not set, so won't send events")

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -45,6 +45,7 @@ def configure(config: Configuration):
             traces_sample_rate=1.0,
             environment=SENTRY_ENVIRONMENT,
             release=release,
+            in_app_include=["eligibility_server"],
         )
     else:
         print("SENTRY_DSN not set, so won't send events")

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -1,7 +1,12 @@
+import os
+
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 from eligibility_server.settings import Configuration
+
+
+SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
 
 
 def configure(config: Configuration):
@@ -12,10 +17,8 @@ def configure(config: Configuration):
             integrations=[
                 FlaskIntegration(),
             ],
-            # Set traces_sample_rate to 1.0 to capture 100%
-            # of transactions for performance monitoring.
-            # We recommend adjusting this value in production.
             traces_sample_rate=1.0,
+            environment=SENTRY_ENVIRONMENT,
         )
     else:
         print("SENTRY_DSN not set, so won't send events")

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -29,6 +29,17 @@ def get_denylist():
     return denylist
 
 
+def get_traces_sample_rate(config: Configuration):
+    rate = config.sentry_traces_sample_rate
+    if rate < 0.0 or rate > 1.0:
+        logger.warning("SENTRY_TRACES_SAMPLE_RATE was not in the range [0.0, 1.0], defaulting to 0.0")
+        rate = 0.0
+    else:
+        logger.info(f"SENTRY_TRACES_SAMPLE_RATE set to: {rate}")
+
+    return rate
+
+
 def configure(config: Configuration):
     SENTRY_DSN = config.sentry_dsn
     if SENTRY_DSN:
@@ -40,7 +51,7 @@ def configure(config: Configuration):
             integrations=[
                 FlaskIntegration(),
             ],
-            traces_sample_rate=1.0,
+            traces_sample_rate=get_traces_sample_rate(config),
             environment=SENTRY_ENVIRONMENT,
             release=release,
             in_app_include=["eligibility_server"],

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import subprocess
 
 import sentry_sdk
@@ -12,23 +11,12 @@ from eligibility_server.settings import Configuration
 SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
 
 
-def git_available():
-    return bool(shutil.which("git"))
-
-
-# https://stackoverflow.com/a/24584384/358804
-def is_git_directory(path="."):
-    dev_null = open(os.devnull, "w")
-    return subprocess.call(["git", "-C", path, "status"], stderr=dev_null, stdout=dev_null) == 0
-
-
 # https://stackoverflow.com/a/21901260/358804
 def get_git_revision_hash():
     return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
 
 
 def get_release() -> str:
-    """Returns the first available: the SHA from Git, the value from sha.txt, or the VERSION."""
     return get_git_revision_hash()
 
 

--- a/eligibility_server/settings.py
+++ b/eligibility_server/settings.py
@@ -43,6 +43,10 @@ CSV_DELIMITER = ","
 CSV_QUOTING = 3
 CSV_QUOTECHAR = '"'
 
+# Sentry
+
+SENTRY_DSN = None
+
 
 class Configuration:
     # App settings
@@ -134,3 +138,10 @@ class Configuration:
     @property
     def csv_quotechar(self):
         return str(current_app.config["CSV_QUOTECHAR"])
+
+    # Sentry
+
+    @property
+    def sentry_dsn(self):
+        sentry_dsn = current_app.config["SENTRY_DSN"]
+        return str(sentry_dsn) if sentry_dsn else None

--- a/eligibility_server/settings.py
+++ b/eligibility_server/settings.py
@@ -5,6 +5,7 @@ from flask import current_app
 
 # App settings
 
+AGENCY_NAME = "[unset]"
 APP_NAME = "eligibility_server.app"
 DEBUG_MODE = True
 HOST = "0.0.0.0"  # nosec
@@ -51,6 +52,10 @@ SENTRY_TRACES_SAMPLE_RATE = 0.0
 
 class Configuration:
     # App settings
+
+    @property
+    def agency_name(self):
+        return str(current_app.config["AGENCY_NAME"])
 
     @property
     def app_name(self):

--- a/eligibility_server/settings.py
+++ b/eligibility_server/settings.py
@@ -46,6 +46,7 @@ CSV_QUOTECHAR = '"'
 # Sentry
 
 SENTRY_DSN = None
+SENTRY_TRACES_SAMPLE_RATE = 0.0
 
 
 class Configuration:
@@ -145,3 +146,7 @@ class Configuration:
     def sentry_dsn(self):
         sentry_dsn = current_app.config["SENTRY_DSN"]
         return str(sentry_dsn) if sentry_dsn else None
+
+    @property
+    def sentry_traces_sample_rate(self):
+        return float(current_app.config["SENTRY_TRACES_SAMPLE_RATE"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "Flask==2.3.3",
     "Flask-RESTful==0.3.10",
     "Flask-SQLAlchemy==3.1.1",
-    "requests==2.31.0"
+    "requests==2.31.0",
+    "sentry-sdk[flask]==1.19.1"
 ]
 
 [project.optional-dependencies]

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -56,6 +56,9 @@ resource "azurerm_linux_web_app" "main" {
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
     "WEBSITES_PORT"                       = "8000"
     "WEBSITES_CONTAINER_START_TIME_LIMIT" = "1800"
+
+    # Sentry
+    "SENTRY_ENVIRONMENT" = "${local.env_name}"
   }
 
   identity {

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -225,3 +225,14 @@ def test_configuration_csv_quotechar(mocker, configuration: Configuration):
     mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
 
     assert configuration.csv_quotechar == new_value
+
+
+@pytest.mark.usefixtures("flask")
+def test_configuration_sentry_dsn(mocker, configuration: Configuration):
+    assert configuration.sentry_dsn is None
+
+    new_value = "https://sentry.example.com"
+    mocked_config = {"SENTRY_DSN": new_value}
+    mocker.patch.dict("eligibility_server.settings.current_app.config", mocked_config)
+
+    assert configuration.sentry_dsn == new_value


### PR DESCRIPTION
Closes #252 
Closes #312 

## How to test / review

Create a new Python settings file in your local `config/` directory, e.g. `config/sentry.py`, with the following contents:

```python
# get the DSN from https://sentry.calitp.org/settings/sentry/projects/eligibility-server/keys/
SENTRY_DSN = "https://..."  

# make up a name for testing
AGENCY_NAME = "Your Transit Agency"
```

In your local `.env` file, make sure to point to your custom settings file: 

```env
ELIGIBILITY_SERVER_SETTINGS=../config/sentry.py
```

Get this branch and rebuild and reopen in the devcontainer.

`F5` to run the app

Go to `http://localhost:PORT/error` to trigger a Sentry error

Log in to Sentry to confirm your details were recorded in the error.

## TODOs
 - [x] ~Figure out / decide on a way to [single-source the version number](https://packaging.python.org/en/latest/guides/single-sourcing-package-version/) and read it when setting `release` for Sentry~ determined that we don't need this. Benefits uses `VERSION` as a fallback, but in practice, we're always getting the git hash.

## Before merging
 - [x] Set `SENTRY_DSN` as a setting for current deployments of `eligibility-server` (it will be within the file that is specified by [`ELIGIBILITY_SERVER_SETTINGS`](https://github.com/cal-itp/eligibility-server/blob/3052d6f43ff3b75f7ea0b2011f95f073885a872b/terraform/app_service.tf#L52))
    - [x] dev
    - [x] test
    - [x] prod
 - [x] Set `AGENCY_NAME` as a setting for current deployments of `eligibility-server` (it will be within the file that is specified by [`ELIGIBILITY_SERVER_SETTINGS`](https://github.com/cal-itp/eligibility-server/blob/3052d6f43ff3b75f7ea0b2011f95f073885a872b/terraform/app_service.tf#L52)). This should match the corresponding [`agency.long_name` from Benefits](https://github.com/cal-itp/benefits/blob/dev/benefits/core/migrations/0002_data.py#L286)
    - [x] dev
    - [x] test
    - [x] prod