### PR TITLE
Chore: update to latest eligibility-api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eligibility-api==2023.01.1
+eligibility-api==2023.6.1
 Flask==2.2.3
 Flask-RESTful==0.3.9
 Flask-SQLAlchemy==3.0.3


### PR DESCRIPTION
See https://github.com/cal-itp/eligibility-api/releases/tag/2023.06.01

Related to https://github.com/cal-itp/benefits/pull/1434