### PR TITLE
Fix: disable app service AlwaysOn

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -19,6 +19,7 @@ resource "azurerm_linux_web_app" "main" {
   https_only          = true
 
   site_config {
+    always_on     = false
     ftps_state    = "Disabled"
     http2_enabled = true
 


### PR DESCRIPTION
This setting is redundant with the `healthcheck` and causes a 404 response since the root URL is not a valid endpoint.

See [Terraform](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app#always_on) and [Azure](https://learn.microsoft.com/en-us/azure/app-service/configure-common?tabs=portal#configure-general-settings) docs.

Closes #272 