### PR TITLE
Fix: match default timeout to benefits

### DIFF
--- a/eligibility_server/settings.py
+++ b/eligibility_server/settings.py
@@ -9,7 +9,7 @@ APP_NAME = "eligibility_server.app"
 DEBUG_MODE = True
 HOST = "0.0.0.0"  # nosec
 LOG_LEVEL = "INFO"
-REQUEST_TIMEOUT = 5
+REQUEST_TIMEOUT = (3, 20)
 
 # Database settings
 
@@ -65,7 +65,7 @@ class Configuration:
 
     @property
     def request_timeout(self):
-        return int(current_app.config["REQUEST_TIMEOUT"])
+        return current_app.config["REQUEST_TIMEOUT"]
 
     # API settings
 

--- a/tests/test_keypair.py
+++ b/tests/test_keypair.py
@@ -5,6 +5,7 @@ import requests
 
 from eligibility_server import keypair
 from eligibility_server.keypair import _read_key_file
+from eligibility_server.settings import REQUEST_TIMEOUT
 
 
 @pytest.fixture
@@ -50,7 +51,7 @@ def test_read_key_file_remote(sample_key_path_remote, spy_open, spy_requests_get
     # check that there was no call to open
     assert spy_open.call_count == 0
     # check that we made a get request
-    spy_requests_get.assert_called_once_with(sample_key_path_remote, timeout=5)
+    spy_requests_get.assert_called_once_with(sample_key_path_remote, timeout=REQUEST_TIMEOUT)
     assert key
     assert key == requests.get(sample_key_path_remote, timeout=5).text.encode("utf8")
 


### PR DESCRIPTION
Makes the default setting more useful and helps avoid the problem we were seeing related to the fix in https://github.com/cal-itp/benefits/pull/1738