### PR TITLE
Feat: deploy for pre-release or release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,9 @@ on:
       - dev
       - test
       - prod
+  release:
+    types:
+      - published
 
 defaults:
   run:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,9 +15,12 @@ defaults:
   run:
     shell: bash
 
-concurrency:
+env:
   # this expression works like a ternary operation (see https://github.com/actions/runner/issues/409#issuecomment-727565588)
-  group: ${{ github.event_name != 'release' && github.ref_name || github.event.release.prerelease && 'test' || 'prod' }}
+  - DEPLOYMENT_ENVIRONMENT: ${{ github.event_name != 'release' && github.ref_name || github.event.release.prerelease && 'test' || 'prod' }}
+
+concurrency:
+  group: ${{ env.DEPLOYMENT_ENVIRONMENT }}
   cancel-in-progress: true
 
 jobs:
@@ -29,7 +32,7 @@ jobs:
     needs: test
     if: always() && !cancelled() && (github.event_name != 'release' || needs.test.result == 'success')
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name != 'release' && github.ref_name || github.event.release.prerelease && 'test' || 'prod' }}
+    environment: ${{ env.DEPLOYMENT_ENVIRONMENT }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,12 +15,15 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  # this expression works like a ternary operation (see https://github.com/actions/runner/issues/409#issuecomment-727565588)
+  group: ${{ github.event_name != 'release' && github.ref_name || github.event.release.prerelease && 'test' || 'prod' }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # this expression works like a ternary operation (see https://github.com/actions/runner/issues/409#issuecomment-727565588)
     environment: ${{ github.event_name != 'release' && github.ref_name || github.event.release.prerelease && 'test' || 'prod' }}
-    concurrency: ${{ github.event_name != 'release' && github.ref_name || github.event.release.prerelease && 'test' || 'prod' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,5 +60,6 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
+            ghcr.io/${{ github.repository }}:${{ env.DEPLOYMENT_ENVIRONMENT }}
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    uses: ./.github/workflows/run-tests.yml
+    if: github.event_name == 'release' && (github.event.release.prerelease || !github.event.release.prerelease)
+
   deploy:
+    needs: test
+    if: always() && !cancelled() && (github.event_name != 'release' || needs.test.result == 'success')
     runs-on: ubuntu-latest
     environment: ${{ github.event_name != 'release' && github.ref_name || github.event.release.prerelease && 'test' || 'prod' }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   test:
     uses: ./.github/workflows/run-tests.yml
-    if: github.event_name == 'release' && (github.event.release.prerelease || !github.event.release.prerelease)
+    if: github.event_name == 'release'
 
   deploy:
     needs: test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,8 +18,9 @@ defaults:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_name }}
-    concurrency: ${{ github.ref_name }}
+    # this expression works like a ternary operation (see https://github.com/actions/runner/issues/409#issuecomment-727565588)
+    environment: ${{ github.event_name != 'release' && github.ref_name || github.event.release.prerelease && 'test' || 'prod' }}
+    concurrency: ${{ github.event_name != 'release' && github.ref_name || github.event.release.prerelease && 'test' || 'prod' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
 
   deploy:
     needs: test
-    if: always() && !cancelled() && (github.event_name != 'release' || needs.test.result == 'success')
+    if: (!cancelled() && (github.event_name != 'release' || needs.test.result == 'success'))
     runs-on: ubuntu-latest
     environment: ${{ env.DEPLOYMENT_ENVIRONMENT }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,6 +30,8 @@ jobs:
 
   deploy:
     needs: test
+    # !cancelled() is needed because if the whole workflow was cancelled, we don't want this job to run.
+    # (github.event_name != 'release' || needs.test.result == 'success') is needed because if `test` did run, we only want this to run if `test` succeeded.
     if: (!cancelled() && (github.event_name != 'release' || needs.test.result == 'success'))
     runs-on: ubuntu-latest
     environment: ${{ env.DEPLOYMENT_ENVIRONMENT }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,7 @@
 name: Run pytests
 
 on:
+  workflow_call:
   pull_request:
     branches: ["*"]
 


### PR DESCRIPTION
Part of #286 

This PR adds to our `Deploy` GitHub workflow so that it can be triggered by a GitHub release (either pre- or full release will work).

These are all the code changes needed to implement #286; the last two tasks on the issue are changes to settings for the GitHub repo.