### PR TITLE
Fix: add app setting needed to enable GitHub CI/CD webhook

### DIFF
--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -49,6 +49,7 @@ resource "azurerm_linux_web_app" "main" {
   }
 
   app_settings = {
+    "DOCKER_ENABLE_CI"            = "true",
     "DOCKER_REGISTRY_SERVER_URL"  = "https://ghcr.io/"
     "ELIGIBILITY_SERVER_SETTINGS" = "${local.mount_path}/settings.py"
     # this prevents the filesystem from being obscured by a mount


### PR DESCRIPTION
While trying to show @allejo how our webhook works to push a new Docker image to the Azure app service, we realized "Continuous deployment" was set to off, which seemed odd.

See https://learn.microsoft.com/en-us/azure/app-service/deploy-ci-cd-custom-container?tabs=acr&pivots=container-linux#4-enable-cicd for more details on how that setting works, but basically we realized that the webhook has not been working all this time.