### PR TITLE
Fix: custom rule name

### DIFF
--- a/terraform/front_door.tf
+++ b/terraform/front_door.tf
@@ -74,7 +74,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "main" {
   custom_block_response_body        = base64encode("Forbidden")
 
   custom_rule {
-    name     = "public_access"
+    name     = "publicaccess"
     enabled  = true
     type     = "MatchRule"
     priority = 1


### PR DESCRIPTION
I noticed that our infra pipeline failed to apply the change from #338 

The message from the [build](https://dev.azure.com/mstransit/courtesy-cards/_build/results?buildId=355&view=logs&j=de9ad78b-21c3-52d3-f75b-ac0998b9a9c9&t=9f0d2323-8cb9-5ca6-9fa8-c6837cb4c41d&l=33) says:
> ` Error: updating Front Door Firewall Policy: (Front Door Web Application Firewall Policy Name "devwaf" / Resource Group "courtesy-cards-eligibility-dev"): frontdoor.PoliciesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="BadRequest" Message="WebApplicationFirewallPolicy validation failed. More information \"Rule name must start with a letter and contain only numbers and letters\"."`

It was my bad on not remembering what characters are allowed in custom rule names when I suggested the name `public_access` 😓 

This PR fixes the name