### PR TITLE
Fix: use agency card as prefix for key vault name

### DIFF
--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -1,6 +1,6 @@
 resource "azurerm_key_vault" "main" {
   # name needs to be globally unique
-  name                = "eligibility-server-${local.env_name}"
+  name                = "${var.AGENCY_CARD}-${local.env_name}"
   location            = data.azurerm_resource_group.main.location
   resource_group_name = data.azurerm_resource_group.main.name
   sku_name            = "standard"


### PR DESCRIPTION
Closes #353 

Use the agency card name instead of a hard-coded `eligibility-server`. Key Vault names are limited to 24 characters.

Note that this will rename MST's key vault, which is ok because it just contains the Slack email for notifications.

### Post-approval
- [x] Manually delete MST key vault since `lifecycle.prevent_destroy` is set to `true`

### Post-merge
- [ ] Add back slack email secret for MST
- [ ] Add slack email secret for SBMTD