### PR TITLE
Feat: version from git metadata

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,11 +5,5 @@ COPY docs/requirements.txt docs/requirements.txt
 RUN pip install --no-cache-dir -r docs/requirements.txt
 
 # install devcontainer requirements
+COPY .git .git
 RUN pip install -e .[dev,test]
-
-# install pre-commit environments in throwaway Git repository
-# https://stackoverflow.com/a/68758943
-COPY .pre-commit-config.yaml .
-RUN git init . && \
-    pre-commit install-hooks && \
-    rm -rf .git

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
   "service": "dev",
   "runServices": ["dev", "docs"],
   "workspaceFolder": "/home/calitp/app",
+  "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
   "postStartCommand": ["/bin/bash", "bin/init.sh"],
   "customizations": {
     // Set *default* container specific settings.json values on container create.

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+
+pre-commit install --install-hooks

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git/
 .github/
 .vscode/
 .flake8

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,10 +9,7 @@
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
-  "python.formatting.provider": "none",
   "python.languageServer": "Pylance",
-  "python.linting.enabled": true,
-  "python.linting.flake8Enabled": true,
   "python.testing.pytestArgs": ["tests"],
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,17 @@ ENV FLASK_APP=eligibility_server/app.py
 RUN python -m pip install --upgrade pip
 
 # copy source files
+COPY .git .git
 COPY bin bin
 COPY eligibility_server/ eligibility_server/
 COPY pyproject.toml pyproject.toml
 
 # install source as a package
 RUN pip install -e .
+
+USER root
+RUN rm -rf .git/
+USER $USER
 
 # start app
 ENTRYPOINT ["/bin/bash"]

--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -4,14 +4,13 @@ Simple Test Eligibility Verification API Server.
 import logging
 
 from flask import Flask, jsonify, make_response
-from flask_restful import Api
 from flask.logging import default_handler
+from flask_restful import Api
 
-from eligibility_server import db, sentry
+from eligibility_server import __version__, db, sentry
 from eligibility_server.keypair import get_server_public_key
 from eligibility_server.settings import Configuration
 from eligibility_server.verify import Verify
-
 
 config = Configuration()
 
@@ -29,6 +28,7 @@ with app.app_context():
     # configure Flask's logger
     app.logger.setLevel(config.log_level)
     default_handler.formatter = logging.Formatter(format_string)
+    app.logger.info(f"Starting Eligibility Server {__version__}")
 
 
 def TextResponse(content):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "black",
     "flake8",
     "pre-commit",
+    "setuptools_scm>=8"
 ]
 test = [
     "coverage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eligibility-server"
-version = "2023.09.1"
+dynamic = ["version"]
 description = "Server implementation of the Eligibility Verification API"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -33,7 +33,7 @@ Documentation = "https://docs.calitp.org/eligibility-server"
 Issues = "https://github.com/cal-itp/eligibility-server/issues"
 
 [build-system]
-requires = ["setuptools>=65", "wheel"]
+requires = ["setuptools>=65", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
@@ -46,3 +46,6 @@ include = ["eligibility_server", "tests"]
 
 [tool.setuptools]
 packages = ["eligibility_server"]
+
+[tool.setuptools_scm]
+# intentionally left blank, but we need the section header to activate the tool

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -38,4 +38,4 @@ def test_version():
     from eligibility_server import __version__
 
     assert __version__ is not None
-    assert re.match(r"\d{4}\.\d{1,2}\.\d+", __version__)
+    assert re.match(r"\d+\.\d+\..+", __version__)


### PR DESCRIPTION
Closes #287

I'm noticing that `setuptools_scm` seems to want an _annotated_ tag, because it uses

```
git describe
```

To get the version, which by default only lists annotated tags. See more: 

* https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme
* https://git-scm.com/docs/git-describe#_description