### PR TITLE
Fix: triggers for app-service restart pipeline

### DIFF
--- a/terraform/mst/azure-restart.yml
+++ b/terraform/mst/azure-restart.yml
@@ -6,11 +6,7 @@ schedules:
       - dev
     always: true
 
-trigger:
-  branches:
-    exclude:
-      - "*"
-
+trigger: none
 pr: none
 
 pool:

--- a/terraform/mst/azure-restart.yml
+++ b/terraform/mst/azure-restart.yml
@@ -6,6 +6,11 @@ schedules:
       - dev
     always: true
 
+trigger:
+  branches:
+    exclude:
+      - "*"
+
 pr: none
 
 pool:

--- a/terraform/sbmtd/azure-restart.yml
+++ b/terraform/sbmtd/azure-restart.yml
@@ -6,11 +6,7 @@ schedules:
       - dev
     always: true
 
-trigger:
-  branches:
-    exclude:
-      - "*"
-
+trigger: none
 pr: none
 
 pool:

--- a/terraform/sbmtd/azure-restart.yml
+++ b/terraform/sbmtd/azure-restart.yml
@@ -6,6 +6,11 @@ schedules:
       - dev
     always: true
 
+trigger:
+  branches:
+    exclude:
+      - "*"
+
 pr: none
 
 pool:


### PR DESCRIPTION
In #362, we set up a YAML pipeline definition for restarting SBMTD's app service.

I've noticed that the pipeline is getting triggered when merging into `dev`, which is not intended behavior. For example, when I merged in #382, this [run](https://dev.azure.com/sbmtd/eligibility-server/_build/results?buildId=117&view=results) was triggered.

The intended behavior is that the pipeline is triggered only for the cron schedule.

Re-reading [Azure DevOps docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#branches), I see:
> If you don't specify any triggers, the default is as if you wrote:
> ```
> trigger:
>   branches:
>     include:
>     - '*'  # must quote since "*" is a YAML reserved character; we want a string
> ```

which explains it. The fix is to opt out of CI triggers.

https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#opting-out-of-ci
