### PR TITLE
Fix: ensure nested packages are included in distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ source = ["eligibility_server"]
 include = ["eligibility_server", "tests"]
 
 [tool.setuptools]
-packages = ["eligibility_server"]
+package-dir = {"" = "eligibility_server"}
 
 [tool.setuptools_scm]
 # intentionally left blank, but we need the section header to activate the tool


### PR DESCRIPTION
Follow-up to #382 

Azure app service is failing to start. The logs show this:
```
2023-12-18T18:20:58.529647182Z + bin/init.sh
2023-12-18T18:20:58.561899719Z + flask init-db
2023-12-18T18:21:01.808387128Z Error: While importing 'eligibility_server.app', an ImportError was raised:
2023-12-18T18:21:01.808429029Z
2023-12-18T18:21:01.808433829Z Traceback (most recent call last):
2023-12-18T18:21:01.808437229Z   File "/home/calitp/.local/lib/python3.11/site-packages/flask/cli.py", line 219, in locate_app
2023-12-18T18:21:01.808440729Z     __import__(module_name)
2023-12-18T18:21:01.808444429Z   File "/home/calitp/.local/lib/python3.11/site-packages/eligibility_server/app.py", line 10, in <module>
2023-12-18T18:21:01.808448329Z     from eligibility_server import __version__, db, sentry
2023-12-18T18:21:01.808451929Z ImportError: cannot import name 'db' from 'eligibility_server' (/home/calitp/.local/lib/python3.11/site-packages/eligibility_server/__init__.py)
2023-12-18T18:21:01.808455429Z
2023-12-18T18:21:01.808458329Z
2023-12-18T18:21:01.814854655Z Usage: flask [OPTIONS] COMMAND [ARGS]...
2023-12-18T18:21:01.814875356Z Try 'flask --help' for help.
2023-12-18T18:21:01.814879456Z
2023-12-18T18:21:01.815534669Z Error: No such command 'init-db'.
```

I'm not able to reproduce this locally: `flask init-db` and `./bin/init.sh` both work for me. However, I do see that the sdist (tarball) and the wheel are not including the `eligibility_server.db` package, so in this PR, we tweak the configuration so that nested packages will be included.

See https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#package-discovery-and-namespace-packages for documentation on this configuration change.