### PR TITLE
Fix: wheel did not contain a 'eligibility_server' directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,9 @@ source = ["eligibility_server"]
 [tool.pyright]
 include = ["eligibility_server", "tests"]
 
-[tool.setuptools]
-package-dir = {"" = "eligibility_server"}
+[tool.setuptools.packages.find]
+include = ["eligibility_server*"]
+namespaces = false
 
 [tool.setuptools_scm]
 # intentionally left blank, but we need the section header to activate the tool


### PR DESCRIPTION
Follow-up to #389 

Our Azure app service is still failing to start up the container, now with a slightly different message:

```
023-12-19T20:39:48.730935526Z + bin/init.sh
2023-12-19T20:39:48.790546218Z + flask init-db
2023-12-19T20:39:52.559070985Z Error: Could not import 'eligibility_server.app'.
2023-12-19T20:39:52.559129386Z
2023-12-19T20:39:52.561129326Z Usage: flask [OPTIONS] COMMAND [ARGS]...
2023-12-19T20:39:52.561150627Z Try 'flask --help' for help.
2023-12-19T20:39:52.561155527Z
2023-12-19T20:39:52.568523774Z Error: No such command 'init-db'.
```

It seems that it can't find our app at `eligibility_server.app` . Locally, I cannot reproduce this.

However, inspecting the wheel locally, I see that the structure is:
```
$ unzip -l /build/dist/eligibility_server-2023.11.1rc2.dev27+g056f5f5-py3-none-any.whl 
Archive:  /build/dist/eligibility_server-2023.11.1rc2.dev27+g056f5f5-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
      184  2023-12-08 19:32   __init__.py
     2747  2023-12-18 17:40   app.py
      834  2023-12-08 19:32   hash.py
     1049  2023-12-08 19:32   keypair.py
     2031  2023-12-08 19:32   sentry.py
     3512  2023-12-08 19:32   settings.py
     5675  2023-12-08 19:32   verify.py
      296  2023-12-08 19:32   db/__init__.py
      866  2023-12-08 19:32   db/models.py
     4455  2023-12-18 17:40   db/setup.py
    34539  2023-12-19 20:47   eligibility_server-2023.11.1rc2.dev27+g056f5f5.dist-info/LICENSE
    41279  2023-12-19 20:47   eligibility_server-2023.11.1rc2.dev27+g056f5f5.dist-info/METADATA
       92  2023-12-19 20:47   eligibility_server-2023.11.1rc2.dev27+g056f5f5.dist-info/WHEEL
       52  2023-12-19 20:47   eligibility_server-2023.11.1rc2.dev27+g056f5f5.dist-info/top_level.txt
     1219  2023-12-19 20:47   eligibility_server-2023.11.1rc2.dev27+g056f5f5.dist-info/RECORD
---------                     -------
    98830                     15 files
```

And running `ls /home/calitp/.local/lib/python3.11/site-packages/`, I see that the files are installed directly into that directory (`hash.py`, `app.py`, etc.).

This PR tweaks the `setuptools` configuration so that the wheel still contains the `eligibility_server.db` module (what #389 was trying to address) _and_ is built with an `eligibility_server` directory.

```
$ unzip -l /build/dist/eligibility_server-2023.11.1rc2.dev27+g056f5f5.d20231219-py3-none-any.whl 
Archive:  /build/dist/eligibility_server-2023.11.1rc2.dev27+g056f5f5.d20231219-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
      184  2023-12-08 19:32   eligibility_server/__init__.py
     2747  2023-12-18 17:40   eligibility_server/app.py
      834  2023-12-08 19:32   eligibility_server/hash.py
     1049  2023-12-08 19:32   eligibility_server/keypair.py
     2031  2023-12-08 19:32   eligibility_server/sentry.py
     3512  2023-12-08 19:32   eligibility_server/settings.py
     5675  2023-12-08 19:32   eligibility_server/verify.py
      296  2023-12-08 19:32   eligibility_server/db/__init__.py
      866  2023-12-08 19:32   eligibility_server/db/models.py
     4455  2023-12-18 17:40   eligibility_server/db/setup.py
    34539  2023-12-19 21:13   eligibility_server-2023.11.1rc2.dev27+g056f5f5.d20231219.dist-info/LICENSE
    41289  2023-12-19 21:13   eligibility_server-2023.11.1rc2.dev27+g056f5f5.d20231219.dist-info/METADATA
       92  2023-12-19 21:13   eligibility_server-2023.11.1rc2.dev27+g056f5f5.d20231219.dist-info/WHEEL
       19  2023-12-19 21:13   eligibility_server-2023.11.1rc2.dev27+g056f5f5.d20231219.dist-info/top_level.txt
     1459  2023-12-19 21:13   eligibility_server-2023.11.1rc2.dev27+g056f5f5.d20231219.dist-info/RECORD
---------                     -------
    99047                     15 files
```