### PR TITLE
Fix: published static file location

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,7 @@ jobs:
           cache-dependency-path: "**/pyproject.toml"
 
       - name: Create /static directory
-        run: mkdir -p eligibility_server/static
+        run: mkdir -p static
 
       - name: Write python packages to file
         run: |
@@ -60,10 +60,10 @@ jobs:
           pip install pipdeptree
           pip install -e .
           pipdeptree
-          pipdeptree >> eligibility_server/static/requirements.txt
+          pipdeptree >> static/requirements.txt
 
       - name: Write commit SHA to file
-        run: echo "${{ github.sha }}" >> eligibility_server/static/sha.txt
+        run: echo "${{ github.sha }}" >> static/sha.txt
 
       - name: Docker Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 config/*
 !config/sample.py
 eligibility_server.egg-info
+static/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN python -m pip install --upgrade pip
 COPY . .
 RUN git config --global --add safe.directory /build
 
+RUN mkdir -p static
+
 # build as root user so unnecessary files are not copied into tarball
 USER root
 RUN pip install build && python -m build
@@ -19,6 +21,7 @@ WORKDIR /home/calitp/app
 ENV FLASK_APP=eligibility_server.app:app
 
 COPY --from=build_wheel /build/dist /build/dist
+COPY --from=build_wheel /build/static static
 
 # copy source files
 COPY bin bin


### PR DESCRIPTION
While working on #288 with @thekaveman, we noticed we're getting 404s for the static files.

This PR fixes the `docker-publish` workflow to create the static files at the correct place in the directory structure.

Note: In Benefits, the `deploy` workflow creates `sha.txt` and `requirements.txt` in `benefits/static` because Django's `compilestatic` command will move them to `static`.