### PR TITLE
Fix: Bugs with Sentry configuration

### DIFF
--- a/eligibility_server/app.py
+++ b/eligibility_server/app.py
@@ -22,12 +22,12 @@ format_string = "[%(asctime)s] %(levelname)s %(name)s:%(lineno)s %(message)s"
 
 # use an app context for access to config settings
 with app.app_context():
-    sentry.configure(config)
     # configure root logger first, to prevent duplicate log entries from Flask's logger
     logging.basicConfig(level=config.log_level, format=format_string)
     # configure Flask's logger
     app.logger.setLevel(config.log_level)
     default_handler.formatter = logging.Formatter(format_string)
+    sentry.configure(config)
     app.logger.info(f"Starting Eligibility Server {__version__}")
 
 

--- a/eligibility_server/sentry.py
+++ b/eligibility_server/sentry.py
@@ -1,11 +1,11 @@
 import logging
 import os
-import subprocess
 
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.scrubber import EventScrubber, DEFAULT_DENYLIST
 
+from eligibility_server import __version__
 from eligibility_server.settings import Configuration
 
 logger = logging.getLogger(__name__)
@@ -14,13 +14,8 @@ logger = logging.getLogger(__name__)
 SENTRY_ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "local")
 
 
-# https://stackoverflow.com/a/21901260/358804
-def get_git_revision_hash():
-    return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
-
-
 def get_release() -> str:
-    return get_git_revision_hash()
+    return __version__
 
 
 def get_denylist():


### PR DESCRIPTION
Fixes a bug with Sentry trying to derive the `release` from git metadata using subprocess calls. Instead, use the app's `__version__` directly, which is similarly derived via `setuptools_scm` (#376, #382).

Also, call the Sentry configuration later, after logging is setup -- so that log statements from the Sentry configuration work.