### PR TITLE
Fix: avoid tag checkout collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The `release` workflow for `2024.01.3` [failed with an error](https://github.com/cal-itp/eligibility-server/actions/runs/7465829014) about a not being able to store a commit and a tag under the same reference:

![image](https://github.com/cal-itp/eligibility-server/assets/25497886/abd45c68-1ada-49d9-9f6c-6652636181c5)

See https://github.com/actions/checkout/issues/1467 for some discussion

This PR attempts to fix the issue by just fetching the history rather than the tags.