### PR TITLE
Fix: make path filter work for tags

### DIFF
--- a/terraform/mst/azure-pipelines.yml
+++ b/terraform/mst/azure-pipelines.yml
@@ -4,10 +4,8 @@ trigger:
       - dev
       - test
       - prod
-  tags:
-    include:
-      - 20??.??.?*-rc?*
-      - 20??.??.?*
+      - refs/tags/20??.??.?*-rc?*
+      - refs/tags/20??.??.?*
   # only run for changes to Terraform files
   paths:
     include:

--- a/terraform/sbmtd/azure-pipelines.yml
+++ b/terraform/sbmtd/azure-pipelines.yml
@@ -4,10 +4,8 @@ trigger:
       - dev
       - test
       - prod
-  tags:
-    include:
-      - 20??.??.?*-rc?*
-      - 20??.??.?*
+      - refs/tags/20??.??.?*-rc?*
+      - refs/tags/20??.??.?*
   # only run for changes to Terraform files
   paths:
     include:


### PR DESCRIPTION
While working on #288, we noticed that even though our CI triggers in `mst/azure-pipelines.yml` and `sbmtd/azure-pipelines.yml` specify that the pipeline should only run if files under `/terraform` are changed, the infra pipeline ran for `2024.01.3-rc1`, which did not contain any `/terraform` changes.

Reading over the [Azure docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#paths) more, we realized that `path` filters only combine with the triggers under `branches`.

This PR refactors the tag patterns so that they're specified under the `branches` section.