### PR TITLE
Chore: ignore .venv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .coverage
 .DS_Store
 .env
+.venv/
 config/*
 !config/sample.py
 eligibility_server.egg-info


### PR DESCRIPTION
This is created during GitHub Actions `docker-publish` workflow and can also be useful for local development.