### PR TITLE
Fix: don't use cached pip dependencies in CI builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,8 +45,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version-file: .github/workflows/.python-version
-          cache: pip
-          cache-dependency-path: "**/pyproject.toml"
 
       - name: Create /static directory
         run: mkdir -p static


### PR DESCRIPTION
This seems to be causing release tags to use the most recent pre-release version of the package.

E.g. the run for [`2024.01.5-rc1`](https://github.com/cal-itp/eligibility-server/actions/runs/7648870812/job/20842368032) correctly installed that version of the package into the Docker image.

Then a subsequent run for [`2024.01.5`](https://github.com/cal-itp/eligibility-server/actions/runs/7648916686/job/20842481403) incorrectly reused the `2024.01.5-rc1` package.