### PR TITLE
Fix: don't use docker build cache in CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,8 +80,6 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: GIT-SHA=${{ github.sha }}
-          cache-from: type=gha,scope=cal-itp
-          cache-to: type=gha,scope=cal-itp,mode=max
           context: .
           file: Dockerfile
           push: true


### PR DESCRIPTION
Follow up to #411 since we are still seeing a cached package version during `docker-publish`.