### PR TITLE
Refactor: move the application directory up a level

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "dockerComposeFile": ["../compose.yml"],
   "service": "dev",
   "runServices": ["dev", "docs"],
-  "workspaceFolder": "/home/calitp/app",
+  "workspaceFolder": "/calitp/app",
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
   "postStartCommand": ["/bin/bash", "bin/init.sh"],
   "customizations": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN pip install build && python -m build
 
 FROM ghcr.io/cal-itp/docker-python-web:main as appcontainer
 
-WORKDIR /home/calitp/app
-
 # upgrade pip
 RUN python -m pip install --upgrade pip
 

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8000"
     volumes:
-      - .:/home/calitp/app/
+      - ./:/calitp/app/
 
   dev:
     build:
@@ -20,7 +20,7 @@ services:
     ports:
       - "8000"
     volumes:
-      - .:/home/calitp/app/
+      - ./:/calitp/app/
 
   docs:
     image: eligibility_server:dev
@@ -29,4 +29,4 @@ services:
     ports:
       - "8001"
     volumes:
-      - .:/home/calitp/app
+      - ./:/calitp/app

--- a/terraform/app_service.tf
+++ b/terraform/app_service.tf
@@ -7,7 +7,7 @@ resource "azurerm_service_plan" "main" {
 }
 
 locals {
-  mount_path = "/home/calitp/app/config"
+  mount_path = "/calitp/app/config"
 }
 
 resource "azurerm_linux_web_app" "main" {


### PR DESCRIPTION
Related to:

* https://github.com/cal-itp/docker-python-web/pull/42
* https://github.com/cal-itp/benefits/pull/2156

This PR should be merged after the one in docker-python-web.

This PR also removes the explicit `WORKDIR` setting in the appcontainer Dockerfile, as the base image already sets the default we want.