### PR TITLE
docs(config): enable integrated table of contents

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ theme:
   name: material
   features:
     - navigation.tabs
+    - toc.integrate
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
closes #428 

Adds integrated table of contents to Documentation site

<img width="1263" alt="image" src="https://github.com/cal-itp/eligibility-server/assets/3673236/2fd09cb5-beb5-482d-8313-085a7433a834">
<img width="1358" alt="image" src="https://github.com/cal-itp/eligibility-server/assets/3673236/0032736d-e9ff-4278-aa2b-84427fcf42a7">
