### PR TITLE
Refactor: remove infra-pipeline approval requirement

### DIFF
--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -99,7 +99,6 @@ stages:
     jobs:
       - deployment: Apply
         condition: succeeded()
-        environment: Approval
         variables:
           - name: workspace
             value: $[ stageDependencies.TerraformPlan.Plan.outputs['setvars.workspace'] ]


### PR DESCRIPTION
Closes #370 

This PR makes it so the `Apply` stage of the infra pipeline doesn't try to ask for the `Approval` [environment](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/environments), which we were using to enforce [manual approval](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/environments?view=azure-devops#use-manual-approval-checks).

I'll also go into Azure DevOps for MST and SBMTD and delete their `Approval` environments since they'll no longer be used.

## Post-merge actions
- [ ] Delete `Approval` environments in Azure DevOps for MST and SBMTD