### PR TITLE
Revert "Refactor: remove infra-pipeline approval requirement"

### DIFF
--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -99,6 +99,7 @@ stages:
     jobs:
       - deployment: Apply
         condition: succeeded()
+        environment: Approval
         variables:
           - name: workspace
             value: $[ stageDependencies.TerraformPlan.Plan.outputs['setvars.workspace'] ]


### PR DESCRIPTION
Reverts cal-itp/eligibility-server#477

Part of #480 and closes #370 

## Post-merge steps
- [ ] Remove manual approval check from `Approval` environments for MST and SBMTD