### PR TITLE
Fix: Remove unique constraint from `sub` field

### DIFF
--- a/eligibility_server/db/models.py
+++ b/eligibility_server/db/models.py
@@ -18,7 +18,7 @@ class Eligibility(db.Model):
 
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    sub = db.Column(db.String, unique=True, nullable=False)
+    sub = db.Column(db.String, unique=False, nullable=False)
     name = db.Column(db.String, unique=False, nullable=False)
     types = db.relationship("Eligibility", secondary=user_eligibility, lazy="subquery", backref=db.backref("users", lazy=True))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ source = ["eligibility_server"]
 
 [tool.pyright]
 include = ["eligibility_server", "tests"]
+typeCheckingMode = "off"
 
 [tool.setuptools.packages.find]
 include = ["eligibility_server*"]


### PR DESCRIPTION
Closes #493 

We're seeing duplicate records in the output file. Since we don't have access to the source data, and a duplicate `sub` doesn't impact a user's ability to verify, we can ignore duplicates.