### PR TITLE
Chore: clean up docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,8 +28,7 @@ jobs:
   deploy:
     needs: test
     # !cancelled() is needed because if the whole workflow was cancelled, we don't want this job to run.
-    # (github.ref_type != 'tag' || needs.test.result == 'success') is needed because if `test` did run, we only want this to run if `test` succeeded.
-    if: (!cancelled() && (github.ref_type != 'tag' || needs.test.result == 'success'))
+    if: (!cancelled())
     runs-on: ubuntu-latest
     environment: ${{ github.ref_type != 'tag' && github.ref_name || contains(github.ref, '-rc') && 'test' || 'prod' }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,6 +64,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -71,6 +74,7 @@ jobs:
       - name: Build, tag, and push image to GitHub Container Registry
         uses: docker/build-push-action@v6
         with:
+          platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
           build-args: GIT-SHA=${{ github.sha }}
           cache-from: type=gha,scope=cal-itp


### PR DESCRIPTION
Closes #487 and adds support for building a multi-platform image.

Making the image multi-platform will streamline creating the Benefits dev container for Mac users since at the moment `bin/build.sh` in Benefits attempts to pull the `eligibility-server` image from GHCR, but when an `linux/arm64` image isn't found, it returns an error.
