### PR TITLE
CI: check server metadata on a schedule

### DIFF
--- a/.github/workflows/check-metadata.py
+++ b/.github/workflows/check-metadata.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+
+import requests
+
+
+def get_agency_url(agency: str):
+    path = Path("./metadata.json")
+    if not path.exists():
+        raise RuntimeError("Metadata file not found")
+
+    config = json.loads(path.read_text())
+    return config[agency]
+
+
+def check_metadata_timestamp(url):
+    now = datetime.now(tz=timezone.utc)
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+
+    data = response.json()
+    ts = data["db"]["timestamp"]
+    timestamp = datetime.fromisoformat(ts)
+
+    if not all((timestamp.year == now.year, timestamp.month == now.month, timestamp.day == now.day)):
+        raise RuntimeError(f"Database timestamp mismatch: {ts}")
+
+
+if __name__ == "__main__":
+    args = sys.argv
+    if len(args) < 2:
+        raise RuntimeError("Usage: check-metadata AGENCY")
+
+    agency = args[1]
+    url = get_agency_url(agency)
+    check_metadata_timestamp(url)

--- a/.github/workflows/check-metadata.yml
+++ b/.github/workflows/check-metadata.yml
@@ -1,0 +1,42 @@
+name: Check server metadata
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * *"
+
+jobs:
+  check-metadata:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        agency: [mst, sbmtd]
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .github/workflows/.python-version
+          cache: pip
+
+      - name: Install libraries
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install requests
+
+      - name: Create config file
+        run: |
+          cat > metadata.json <<- EOM
+          ${{ secrets.METADATA_CHECK_CONFIG }}
+          EOM
+
+      - name: Check server metadata
+        run: python .github/workflows/check-metadata.py ${{ agency }}
+
+      - name: Report failure to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ __pycache__/
 config/*
 !config/sample.py
 eligibility_server.egg-info
+metadata.json
 static/


### PR DESCRIPTION
Closes #515 

## Todo

- [x] Release #512 to `dev`, `test`, and `prod`
- [x] Create `ACTION_MONITORING_SLACK` secret
- [ ] Fill secret value for `ACTION_MONITORING_SLACK`
- [x] Create `METADATA_CHECK_CONFIG` secret
- [x] Fill secret value for `METADATA_CHECK_CONFIG`:

```json
{
  "mst": "https://production-server-url.com/metadata",
  "sbmtd": "https://production-server-url.com/metadata",
}
```

## Reviewing

### Success path

1. Checkout the branch locally, open in devcontainer
2. Create a file `metadata.json` at the root, with contents:

   ```json
   {
     "cst": "http://localhost:8000/metadata"
   }
   ```
3. Run `flask init-db` to ensure metadata is hydrated
4. `F5` to run the app
5. Run the `check-metadata` script: `python .github/workflows/check-metadata.py cst`
6. Confirm no error output. Zero exit code.

### Fail path

1. Modify `eligibility_server/db/setup.py` to make `metadata.timestamp` something other than the correct current date (e.g. change day, month, and/or year)
2. Run `flask init-db` again to hydrate new metadata
3. `F5` to run the app
4. Run the `check-metadata` script: `python .github/workflows/check-metadata.py cst`
5. Confirm error output indicates a timestamp mismatch. Non-zero exit code.

Redo the preceding steps to:

- Make `metadata.users` 0
- Make `metadata.eligibility` an empty list

And in each case, confirm the `check-metadata.py` script fails accordingly.
