### PR TITLE
CI: add `main` tag to Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,6 +83,7 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:${{ github.sha }}
 
       - name: Deploy to MST Azure Web App


### PR DESCRIPTION
Currently, Apple M2 users see a `no matching manifest for linux/arm64/v8 in the manifest list entries` message when trying to pull the `eligibility-server` image from this repository's associated GHCR and the pull fails.

~This PR publishes a `linux/arm64/v8` Docker image so that Apple M2 users can directly pull the `eligibility-server` image.~ 

I tested pulling 

```ghcr.io/cal-itp/eligibility-server:4e1d6c09239ceac913243c61f230fe1c045e2939@sha256:8335d87361c823ccc9eea7a92c28da3fed92c730c4dd33c3a0dbdf27b70f6264```

using an Apple M2, and the pull succeeded. So, the issue is actually due to the Docker image missing the `main` tag. This PR  adds a `main` tag to the Docker image so that it can be pulled directly from the Benefits application (see https://github.com/cal-itp/benefits/pull/2616).