### PR TITLE
Chore: upgrade Terraform tasks

### DIFF
--- a/terraform/pipeline/deploy.yml
+++ b/terraform/pipeline/deploy.yml
@@ -35,8 +35,8 @@ stages:
             displayName: Install Terraform
             inputs:
               terraformVersion: 1.8.5
-          # https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformTask/TerraformTaskV3#readme
-          - task: TerraformTaskV3@3
+          # https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformTask/TerraformTaskV4#readme
+          - task: TerraformTaskV4@4
             displayName: Terraform init
             inputs:
               provider: azurerm
@@ -50,7 +50,7 @@ stages:
               backendAzureRmStorageAccountName: $(TF_STORAGE_ACCOUNT)
               backendAzureRmContainerName: tfstate
               backendAzureRmKey: terraform.tfstate
-          - task: TerraformTaskV3@3
+          - task: TerraformTaskV4@4
             displayName: Select environment
             inputs:
               provider: azurerm
@@ -60,7 +60,7 @@ stages:
               workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
               # service connection
               environmentServiceNameAzureRM: deployer
-          - task: TerraformTaskV3@3
+          - task: TerraformTaskV4@4
             displayName: Terraform plan
             inputs:
               provider: azurerm
@@ -117,8 +117,8 @@ stages:
                   displayName: Install Terraform
                   inputs:
                     terraformVersion: 1.8.5
-                # https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformTask/TerraformTaskV3#readme
-                - task: TerraformTaskV3@3
+                # https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformTask/TerraformTaskV4#readme
+                - task: TerraformTaskV4@4
                   displayName: Terraform init
                   inputs:
                     provider: azurerm
@@ -132,7 +132,7 @@ stages:
                     backendAzureRmStorageAccountName: $(TF_STORAGE_ACCOUNT)
                     backendAzureRmContainerName: tfstate
                     backendAzureRmKey: terraform.tfstate
-                - task: TerraformTaskV3@3
+                - task: TerraformTaskV4@4
                   displayName: Select environment
                   inputs:
                     provider: azurerm
@@ -142,7 +142,7 @@ stages:
                     workingDirectory: "$(System.DefaultWorkingDirectory)/terraform"
                     # service connection
                     environmentServiceNameAzureRM: deployer
-                - task: TerraformTaskV3@3
+                - task: TerraformTaskV4@4
                   displayName: Terraform apply
                   inputs:
                     provider: azurerm


### PR DESCRIPTION
This PR upgrades Terraform task `TerraformTaskV3@3` which doesn't support Azure DevOps Workload identity federation to `TerraformTaskV4@4`which does support it.

## Notes
- According to this [Workload identity federation support table](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/troubleshoot-workload-identity?view=azure-devops#review-pipeline-tasks), there is no need to update `AzureAppServiceManage@0` because it already supports identity federation. 
- `TerraformInstaller@0` does not seem to need identity permissions so an upgrade is not required.
- [`TerraformTaskV4@4`](https://github.com/microsoft/azure-pipelines-terraform/tree/main/Tasks/TerraformTask/TerraformTaskV4) still supports all the commands we use: `init`, `custom`, `plan`, `apply`. The parameters also seem to be the same.
