### PR TITLE
docs: update slack channel name and fix a typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ cp .env.sample .env
 docker compose build server
 ```
 
-### Use the Docker container locally
+### Use the published Docker container locally
 
 ```bash
 docker pull ghcr.io/cal-itp/eligibility-server:dev

--- a/docs/configuration/settings.md
+++ b/docs/configuration/settings.md
@@ -144,7 +144,7 @@ These are the possible values for the `CSV_QUOTING` variable:
 
 Cal-ITP's Sentry instance collects both [errors ("Issues")](https://sentry.calitp.org/organizations/sentry/issues/?project=4) and app [performance info](https://sentry.calitp.org/organizations/sentry/performance/?project=4).
 
-[Alerts are sent to #benefits-notify in Slack.](https://sentry.calitp.org/organizations/sentry/alerts/rules/eligibility-server/10/details/) [Others can be configured.](https://sentry.calitp.org/organizations/sentry/alerts/rules/)
+[Alerts are sent to #notify-benefits in Slack.](https://sentry.calitp.org/organizations/sentry/alerts/rules/eligibility-server/10/details/) [Others can be configured.](https://sentry.calitp.org/organizations/sentry/alerts/rules/)
 
 You can troubleshoot Sentry itself by [turning on debug mode](#debug_mode) and visiting `/error/`.
 

--- a/docs/deployment/infrastructure.md
+++ b/docs/deployment/infrastructure.md
@@ -33,13 +33,13 @@ For browsing the [Azure portal](https://portal.azure.com), you can [switch your 
 
 ## Access restrictions
 
-We restrict which IP addresses that can access the app service by using a Web Application Firewall (WAF) configured on a Front Door. There is an exception for the `/healthcheck` and `/static` paths, which can be accessed by any IP address.
+We restrict which IP addresses can access the app service by using a Web Application Firewall (WAF) configured on a Front Door. There is an exception for the `/healthcheck` and `/static` paths, which can be accessed by any IP address.
 
 The app service itself gives access only to our Front Door and to Azure availability tests.
 
 ## Monitoring
 
-We have [ping tests](https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability) set up to notify about availability of each environment. Alerts go to [#benefits-notify](https://cal-itp.slack.com/archives/C022HHSEE3F).
+We have [ping tests](https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability) set up to notify about availability of each environment. Alerts go to [#notify-benefits](https://cal-itp.slack.com/archives/C022HHSEE3F).
 
 ## Logs
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,7 @@ After initialization, the server is running on `http://localhost` at a port dyna
 
 ### Run healthcheck
 
-To check if the server is running successfully, use your browser to get to the Healthcheck endpoint: `http://localhost:50252/healthcheck`
+To check if the server is running successfully, use your browser to get to the Healthcheck endpoint: `http://localhost:8000/healthcheck` (substituting the dynamically assigned port).
 
 The page should read "Healthy"
 


### PR DESCRIPTION
i decided to take a look at this project documentation and get it set up locally this morning. i was able to follow the steps to run the containerized server with one caveat. for me, `bin/build.sh` failed locally with the following error:
```
The command '/bin/sh -c mkdir -p static' returned a non-zero code: 1
```
i had no trouble creating the directory myself though 🤷 . afterward the same script succeeded and i could access http://localhost:63809/healthcheck as that was the port docker assigned randomly.

as for the non-containerized instructions, they succeeded too. as documented, i had to use `docker ps` to determine which port to check. (it was `32814` and not `50252`).

~i'm still fuzzy on what controls port assignment in docker and given that i saw different behavior than @Scotchester initially, i'm inclined to let sleeping dogs lie until I learn more.~

the proposed changes here are just a point of clarification, a typo fix and an update to the name of the slack channel Sentry posts to.

i stopped shy of updating the references below because i'm under the impression they are definitely still being forwarded correctly.

https://github.com/cal-itp/eligibility-server/blob/12a60a5985a0fd96da734e743399ae420bc0da28/terraform/monitor.tf#L19-L27