### PR TITLE
fix: move git dir command out of postAttach script and into Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,5 +9,7 @@ COPY .git .git
 COPY eligibility_server/ eligibility_server/
 COPY pyproject.toml pyproject.toml
 
+RUN git config --global --add safe.directory /calitp/app
+
 # install devcontainer requirements
 RUN pip install -e .[dev,test]

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -2,6 +2,4 @@
 set -eu
 
 # initialize pre-commit
-
-git config --global --add safe.directory /calitp/app
 pre-commit install --install-hooks


### PR DESCRIPTION
analogous to https://github.com/cal-itp/benefits/pull/3630

i'm under the impression that this is needed because >=git@2.35 tightened up security restrictions related to ambiguous directory ownership and `pip` makes calls to `git` under the hood.

ref: https://cal-itp.slack.com/archives/C037Y3UE71P/p1778616900243949?thread_ts=1778615995.226209&cid=C037Y3UE71P